### PR TITLE
Tests to validate memory protection

### DIFF
--- a/test/test-api/src/lib.rs
+++ b/test/test-api/src/lib.rs
@@ -36,6 +36,8 @@ pub enum AssistOp {
     RefreshTaskIdOffByOne = 21,
     RefreshTaskIdOffByMany = 22,
     ReadNotifications = 23,
+    IllegalAccess = 24,
+    IllegalFunc = 25,
 }
 
 /// Operations that are performed by the test-suite

--- a/test/test-assist/src/main.rs
+++ b/test/test-assist/src/main.rs
@@ -117,6 +117,27 @@ fn illinst(_arg: u32) {
 }
 
 #[inline(never)]
+fn illaccess(_arg: u32) {
+    unsafe {
+        let x_ptr = _arg as *mut u32;
+
+        loop {
+            let mut x: u32 = x_ptr.read_volatile();
+            x = x + 1;
+            x_ptr.write_volatile(x);
+        }
+    }
+}
+
+#[inline(never)]
+fn illfunc(_arg: u32) {
+    unsafe {
+        let f: extern "C" fn() = core::mem::transmute(_arg);
+        f();
+    }
+}
+
+#[inline(never)]
 #[cfg(any(armv7m, armv8m))]
 fn divzero(_arg: u32) {
     unsafe {
@@ -170,6 +191,8 @@ fn main() -> ! {
         (AssistOp::StackOutOfBounds, stackoob),
         (AssistOp::BusError, busfault),
         (AssistOp::IllegalInstruction, illinst),
+        (AssistOp::IllegalAccess, illaccess),
+        (AssistOp::IllegalFunc, illfunc),
     ];
 
     const ALL_NOTIFICATIONS: u32 = !0;


### PR DESCRIPTION
Adds two new tests that verify the memory protection is being correctly
set and that a previous task's memory regions are not available to
another task.