### PR TITLE
chips: Add `qemu.sh` to the chip files.

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -606,6 +606,13 @@ fn build_archive(cfg: &PackageConfig, image_name: &str) -> Result<()> {
     archive
         .copy(chip_dir.join("openocd.gdb"), debug_dir.join("openocd.gdb"))?;
 
+    // Copy `qemu.sh` into the archive if it exists;
+    // not all target may support qemu
+    let qemu_sh = chip_dir.join("qemu.sh");
+    if qemu_sh.exists() {
+        archive.copy(qemu_sh, debug_dir.join("qemu.sh"))?;
+    }
+
     archive.finish()?;
     Ok(())
 }

--- a/chips/fe310-g002/qemu.sh
+++ b/chips/fe310-g002/qemu.sh
@@ -1,0 +1,1 @@
+qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.bin -semihosting -semihosting-config enable=on,userspace=on

--- a/chips/fe310-g003/qemu.sh
+++ b/chips/fe310-g003/qemu.sh
@@ -1,0 +1,1 @@
+qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.bin -semihosting -semihosting-config enable=on,userspace=on


### PR DESCRIPTION
Enables Humility to start any app using that chip within a VM.