### PR TITLE
Move external interrupts into userspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
 name = "drv-fe310-rtc"
 version = "0.1.0"
 dependencies = [
+ "drv-ext-int-ctrl-api",
  "ringbuf",
  "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "riscv-pseudo-atomics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-ext-int-ctrl-api"
+version = "0.1.0"
+dependencies = [
+ "derive-idol-err",
+ "idol",
+ "num-traits",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-fe310-rtc"
 version = "0.1.0"
 dependencies = [
@@ -1049,6 +1060,31 @@ version = "0.1.0"
 dependencies = [
  "drv-onewire",
  "num-traits",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
+name = "drv-riscv-plic-server"
+version = "0.1.0"
+dependencies = [
+ "abi",
+ "build-util",
+ "drv-ext-int-ctrl-api",
+ "idol",
+ "idol-runtime",
+ "indexmap",
+ "num-traits",
+ "phash",
+ "phash-gen",
+ "ringbuf",
+ "riscv 0.8.0 (git+https://github.com/rivosinc/riscv?branch=dev/fawaz/plic)",
+ "riscv-pseudo-atomics",
+ "riscv-semihosting",
+ "ron 0.7.0",
+ "serde",
+ "task-config",
+ "toml",
  "userlib",
  "zerocopy",
 ]
@@ -2596,6 +2632,17 @@ dependencies = [
  "bare-metal 1.0.0",
  "bit_field",
  "embedded-hal",
+]
+
+[[package]]
+name = "riscv"
+version = "0.8.0"
+source = "git+https://github.com/rivosinc/riscv?branch=dev/fawaz/plic#bb206d785d090f2f75209bc16304a02da54584cd"
+dependencies = [
+ "bare-metal 1.0.0",
+ "bit_field",
+ "embedded-hal",
+ "volatile-register",
 ]
 
 [[package]]

--- a/app/demo-hifive-inventor/app.toml
+++ b/app/demo-hifive-inventor/app.toml
@@ -6,7 +6,7 @@ stacksize = 896
 
 [kernel]
 name = "demo-hifive-inventor"
-requires = { flash = 16752, ram = 3232 }
+requires = { flash = 16784, ram = 3472 }
 features = []
 
 [tasks.jefe]
@@ -17,14 +17,29 @@ start = true
 features = ["semihosting-riscv"]
 stacksize = 1536
 
+[tasks.ext_int_ctrl]
+name = "drv-riscv-plic-server"
+priority = 1
+max-sizes = { flash = 4096, ram = 2048 }
+start = true
+features = ["semihosting-riscv"]
+uses = ["plic"]
+interrupts = { "plic.irq" = 0x1 }
+
+[tasks.ext_int_ctrl.config]
+ints = [52]
+tasks = ['"rtc"']
+notification = [1]
+pbits = 3
+
 [tasks.rtc]
 name = "drv-fe310-rtc"
-priority = 1
+priority = 2
 max-sizes = { flash = 16384, ram = 4096 }
 start = true
 features = ["semihosting-riscv"]
+task-slots = ["ext_int_ctrl"]
 uses = ["aon_rtc"]
-interrupts = { "aon_rtc.irq" = 1 }
 
 [tasks.pong]
 name = "task-pong"

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -184,6 +184,7 @@ impl Config {
             self.tasks.keys().cloned().collect::<Vec<_>>().join(",");
         env.insert("HUBRIS_TASKS".to_string(), task_names);
         env.insert("HUBRIS_BOARD".to_string(), self.board.to_string());
+        env.insert("HUBRIS_CHIP_DIR".to_string(), self.chip.to_string());
         env.insert(
             "HUBRIS_APP_TOML".to_string(),
             app_toml_path.to_str().unwrap().to_string(),

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -189,6 +189,18 @@ impl Config {
             app_toml_path.to_str().unwrap().to_string(),
         );
 
+        // WARNING: Because this map provides task ID numbers directly, its
+        // contents can be used to send messages to tasks without creating a
+        // task_slot, so it's possible to deadlock. Use this with caution.
+        let mut task_id_map: BTreeMap<String, u32> = BTreeMap::new();
+        for (i, (name, _)) in self.tasks.iter().enumerate() {
+            task_id_map.insert(name.to_string(), i.try_into().unwrap());
+        }
+        env.insert(
+            "HUBRIS_TASK_ID_MAP".to_string(),
+            ron::ser::to_string(&task_id_map).unwrap(),
+        );
+
         // secure_separation indicates that we have TrustZone enabled.
         // When TrustZone is enabled, the bootloader is secure and hubris is
         // not secure.

--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1533,7 +1533,6 @@ pub struct KernelConfig {
     tasks: Vec<abi::TaskDesc>,
     regions: Vec<abi::RegionDesc>,
     irqs: Vec<abi::Interrupt>,
-    plic: (u32, u32),
     timer: (u32, u32),
 }
 
@@ -1556,7 +1555,6 @@ pub fn make_kconfig(
     let mut regions = vec![];
     let mut task_descs = vec![];
     let mut irqs = vec![];
-    let mut plic = (0x0, 0x0);
     let mut timer = (0x0, 0x0);
 
     // Region 0 is the NULL region, used as a placeholder. It gives no access to
@@ -1586,10 +1584,7 @@ pub fn make_kconfig(
         // TODO: Get rid of this eventually and make a proper implementation of
         //       the configuration for these peripherals.
         if toml.target.as_str().contains("riscv") {
-            if name == "plic" {
-                plic = (p.address, p.size);
-                continue;
-            } else if name == "mtime" {
+            if name == "mtime" {
                 timer.0 = p.address;
                 continue;
             } else if name == "mtimecmp" {
@@ -1823,7 +1818,6 @@ pub fn make_kconfig(
         irqs,
         tasks: task_descs,
         regions,
-        plic,
         timer,
     })
 }

--- a/chips/fe310-g003/chip.toml
+++ b/chips/fe310-g003/chip.toml
@@ -1,7 +1,6 @@
 [aon_rtc]
 address = 0x1000_0040
 size = 64
-interrupts = { irq = 52 }
 
 [gpio0]
 address = 0x10012000
@@ -17,7 +16,8 @@ size = 4096
 
 [plic]
 address = 0x0C00_0000
-size = 3
+size = 0x400_0000
+interrupts = { irq = 11 }
 
 [mtime]
 address = 0x0200_BFF8

--- a/drv/ext-int-ctrl-api/Cargo.toml
+++ b/drv/ext-int-ctrl-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "drv-ext-int-ctrl-api"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+userlib = {path = "../../sys/userlib"}
+zerocopy = "0.6.1"
+num-traits = { version = "0.2.12", default-features = false }
+derive-idol-err = {path = "../../lib/derive-idol-err" }
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[lib]
+test = false
+bench = false
+
+[build-dependencies]
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/drv/ext-int-ctrl-api/build.rs
+++ b/drv/ext-int-ctrl-api/build.rs
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    idol::client::build_client_stub(
+        "../../idl/ext-int-ctrl.idol",
+        "client_stub.rs",
+    )?;
+    Ok(())
+}

--- a/drv/ext-int-ctrl-api/src/lib.rs
+++ b/drv/ext-int-ctrl-api/src/lib.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+
+use derive_idol_err::IdolError;
+use userlib::*;
+
+#[derive(Copy, Clone, Debug, FromPrimitive, IdolError)]
+pub enum ExtIntCtrlError {
+    IRQUnassigned,
+}
+
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/fe310-rtc/Cargo.toml
+++ b/drv/fe310-rtc/Cargo.toml
@@ -6,15 +6,16 @@ edition = "2021"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }
-
-[features]
-semihosting-riscv = [ "riscv-semihosting", "userlib/log-semihosting" ]
-log-null = ["userlib/log-null"]
-
-[target.'cfg(target_arch = "riscv32")'.dependencies]
+drv-ext-int-ctrl-api = {path = "../ext-int-ctrl-api"}
 riscv = { version = "0.8" }
 riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", optional = true, features = ["default", "user-mode"] }
 riscv-pseudo-atomics = { git = "https://github.com/rivosinc/riscv-psuedo-atomics", branch = "rivos/main", features = ["default", "user-mode"] }
+
+
+[features]
+semihosting-riscv = [ "riscv-semihosting", "userlib/log-semihosting" ]
+log-stringbuf = ["userlib/log-stringbuf"]
+log-null = ["userlib/log-null"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/drv/riscv-plic-server/Cargo.toml
+++ b/drv/riscv-plic-server/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "drv-riscv-plic-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+userlib = {path = "../../sys/userlib" }
+phash = { path = "../../lib/phash" }
+zerocopy = "0.6.1"
+num-traits = { version = "0.2.12", default-features = false }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "dev/fawaz/plic" }
+riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", optional = true, features = ["default", "user-mode"] }
+riscv-pseudo-atomics = { git = "https://github.com/rivosinc/riscv-psuedo-atomics", branch = "rivos/main", features = ["default", "user-mode"] }
+drv-ext-int-ctrl-api = { path = "../ext-int-ctrl-api" }
+idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
+ringbuf = { path = "../../lib/ringbuf" }
+
+[build-dependencies]
+build-util = {path = "../../build/util"}
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+task-config = { path = "../../lib/task-config" }
+abi = {path = "../../sys/abi" }
+phash-gen = {path = "../../build/phash-gen"}
+ron = "0.7"
+toml = "0.5.6"
+serde = { version = "1.0.114", features = ["derive"] }
+indexmap = { version = "1.4.0" }
+
+[features]
+semihosting-riscv = [ "riscv-semihosting", "userlib/log-semihosting" ]
+log-stringbuf = [ "userlib/log-stringbuf" ]
+log-null = ["userlib/log-null"]
+
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "drv-riscv-plic-server"
+test = false
+bench = false

--- a/drv/riscv-plic-server/build.rs
+++ b/drv/riscv-plic-server/build.rs
@@ -1,0 +1,173 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+task_config::task_config! {
+    ints: &'static [u16],
+    tasks: &'static [&'static str],
+    notification: &'static [u32],
+    pbits: u8,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[allow(dead_code)]
+struct Peripheral {
+    pub address: u32,
+    pub size: u32,
+    #[serde(default)]
+    pub interrupts: BTreeMap<String, u32>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    build_util::expose_target_board();
+
+    idol::server::build_server_support(
+        "../../idl/ext-int-ctrl.idol",
+        "server_stub.rs",
+        idol::server::ServerStyle::InOrder,
+    )?;
+
+    let mut file = {
+        let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("plic_config.rs")).unwrap()
+    };
+
+    let plic_base: u32 = {
+        let mut path: String = env::var("HUBRIS_CHIP_DIR").unwrap();
+        path.push_str("/chip.toml");
+        let chip_contents = std::fs::read(path)?;
+        let peripherals: IndexMap<String, Peripheral> =
+            toml::from_slice(&chip_contents)?;
+        peripherals.get("plic").unwrap().address
+    };
+
+    writeln!(
+        file,
+        "use phash::{{PerfectHashMap, MutablePerfectHashMap}};"
+    )?;
+
+    writeln!(
+        file,
+        "const PLIC_PRIORITY_BITS: usize = 0x{:X};",
+        TASK_CONFIG.pbits
+    )?;
+
+    writeln!(file, "const PLIC_REGISTER_BLOCK: *mut Plic<PLIC_PRIORITY_BITS> = 0x{:X} as *mut Plic<PLIC_PRIORITY_BITS>;", plic_base)?;
+    writeln!(file, "type Priority = plic::Priority<PLIC_PRIORITY_BITS>;")?;
+
+    use abi::{InterruptNum, InterruptOwner, TaskId};
+    let fmt_irq_task = |v: Option<&(InterruptNum, (TaskId, u32))>| {
+        match v {
+            Some((irq, owner)) => format!(
+                "(userlib::InterruptNum({}), (TaskId({}), 0b{:b})),",
+                irq.0, owner.0.0, owner.1
+            ),
+            None => "(userlib::InterruptNum::invalid(), userlib::InterruptOwner::invalid()),"
+                .to_string(),
+        }
+    };
+
+    let fmt_task_irq = |v: Option<&(InterruptOwner, Vec<InterruptNum>)>| {
+        match v {
+            Some((owner, irqs)) => format!(
+                "(userlib::InterruptOwner {{ task: {}, notification: 0b{:b} }}, &[{}]),",
+                owner.task, owner.notification,
+                irqs.iter()
+                    .map(|i| format!("userlib::InterruptNum({})", i.0))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            None => {
+                "(TaskId::IndexMask - 1, &[]),"
+                    .to_string()
+            }
+        }
+    };
+
+    println!("{}", &env::var("HUBRIS_TASK_ID_MAP")?);
+    let task_id_map: std::collections::BTreeMap<String, u16> =
+        ron::de::from_str(&env::var("HUBRIS_TASK_ID_MAP")?)?;
+
+    let mut irq_task_map: Vec<(InterruptNum, (TaskId, u32))> = Vec::new();
+    let mut per_task_irqs: HashMap<InterruptOwner, Vec<InterruptNum>> =
+        HashMap::new();
+
+    for (i, irq) in TASK_CONFIG.ints.into_iter().enumerate() {
+        let task: String = TASK_CONFIG.tasks[i].to_string();
+        let task_id: TaskId = match task_id_map.get(&task) {
+            Some(id_num) => TaskId(*id_num),
+            None => panic!("Error: no matching task ID for task {}", task),
+        };
+
+        let int_num: InterruptNum = InterruptNum(*irq as u32);
+
+        let notification: u32 = TASK_CONFIG.notification[i];
+
+        irq_task_map.push((int_num, (task_id, notification)));
+
+        let owner: InterruptOwner = InterruptOwner {
+            task: task_id.index() as u32,
+            notification: notification,
+        };
+        per_task_irqs.entry(owner).or_default().push(int_num);
+    }
+
+    let task_irq_map: Vec<(InterruptOwner, Vec<InterruptNum>)> =
+        per_task_irqs.into_iter().collect::<Vec<_>>();
+
+    if let Ok(irq_task_map) =
+        phash_gen::OwnedPerfectHashMap::build(irq_task_map.clone())
+    {
+        // Generate text for the Interrupt and InterruptSet tables stored in the
+        // PerfectHashes
+        let irq_task_value = irq_task_map
+            .values
+            .iter()
+            .map(|o| fmt_irq_task(o.as_ref()))
+            .collect::<Vec<String>>()
+            .join("\n        ");
+
+        writeln!(file, "
+static mut HUBRIS_IRQ_TASK_LOOKUP: MutablePerfectHashMap::<userlib::InterruptNum, (TaskId, u32)> = MutablePerfectHashMap {{
+m: {:#x},
+values: &mut [
+    {}
+],
+}};",
+            irq_task_map.m, irq_task_value)?;
+    } else {
+        panic!("Can't make HUBRIS_IRQ_TASK_LOOKUP");
+    }
+
+    if let Ok(task_irq_map) =
+        phash_gen::OwnedPerfectHashMap::build(task_irq_map.clone())
+    {
+        let task_irq_value = task_irq_map
+            .values
+            .iter()
+            .map(|o| fmt_task_irq(o.as_ref()))
+            .collect::<Vec<String>>()
+            .join("\n        ");
+        writeln!(file, "
+pub const HUBRIS_TASK_IRQ_LOOKUP: PerfectHashMap::<userlib::InterruptOwner, &'static [userlib::InterruptNum]> = PerfectHashMap {{
+m: {:#x},
+values: &[
+    {}
+],
+}};",
+            task_irq_map.m, task_irq_value)?;
+    } else {
+        panic!("Can't make HUBRIS_TASK_IRQ_LOOKUP");
+    }
+
+    Ok(())
+}

--- a/drv/riscv-plic-server/src/main.rs
+++ b/drv/riscv-plic-server/src/main.rs
@@ -1,0 +1,202 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+use riscv::plic;
+use riscv::plic::Plic;
+use userlib::*;
+
+use core::result::Result;
+
+use drv_ext_int_ctrl_api::ExtIntCtrlError;
+use idol_runtime::RequestError;
+use idol_runtime::RequestError::Runtime;
+
+const PLIC_IRQ: u32 = 0x0000_0001;
+
+fn get_irq_owner(irq: u32) -> Result<(TaskId, u32), ()> {
+    return match unsafe { HUBRIS_IRQ_TASK_LOOKUP.get(InterruptNum(irq)) } {
+        Some(task) => return Ok(*task),
+        None => Err(()),
+    };
+}
+
+fn set_irq_owner(irq: u32, owner: (TaskId, u32)) -> Result<(), ()> {
+    return unsafe { HUBRIS_IRQ_TASK_LOOKUP.set(InterruptNum(irq), owner) };
+}
+
+fn get_task_irqs(
+    owner: InterruptOwner,
+) -> Result<&'static [userlib::InterruptNum], ()> {
+    return match HUBRIS_TASK_IRQ_LOOKUP.get(owner) {
+        Some(irqs) => Ok(irqs),
+        None => Err(()),
+    };
+}
+
+fn irq_assigned(irq: u32) -> bool {
+    return unsafe { HUBRIS_IRQ_TASK_LOOKUP.contains(InterruptNum(irq)) };
+}
+
+#[repr(C)]
+struct ServerImpl {}
+
+impl idl::InOrderExtIntCtrlImpl for ServerImpl {
+    /// Disables the selected interrupt on the PLIC.
+    fn disable_int(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        irq: u32,
+    ) -> Result<(), RequestError<ExtIntCtrlError>> {
+        let owner: InterruptOwner = InterruptOwner {
+            task: msg.sender.index() as u32,
+            notification: irq,
+        };
+
+        match get_task_irqs(owner) {
+            Ok(irqs) => {
+                let plic = unsafe { &mut *PLIC_REGISTER_BLOCK };
+                for irq in irqs.iter() {
+                    plic.mask(0, irq.0.try_into().unwrap());
+                }
+
+                return Ok(());
+            }
+            Err(()) => return Err(Runtime(ExtIntCtrlError::IRQUnassigned)),
+        }
+    }
+
+    /// Enables the selected interrupt on the PLIC.
+    fn enable_int(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        irq: u32,
+    ) -> Result<(), RequestError<ExtIntCtrlError>> {
+        let owner: InterruptOwner = InterruptOwner {
+            task: msg.sender.index() as u32,
+            notification: irq,
+        };
+
+        match get_task_irqs(owner) {
+            Ok(irqs) => {
+                let plic = unsafe { &mut *PLIC_REGISTER_BLOCK };
+                for irq in irqs.iter() {
+                    plic.unmask(0, irq.0.try_into().unwrap());
+                }
+
+                return Ok(());
+            }
+            Err(()) => return Err(Runtime(ExtIntCtrlError::IRQUnassigned)),
+        }
+    }
+
+    /// Completes the interrupt on the PLIC, allowing for a new one to come
+    /// through.
+    fn complete_int(
+        &mut self,
+        msg: &userlib::RecvMessage,
+        irq: u32,
+    ) -> Result<(), RequestError<ExtIntCtrlError>> {
+        let owner: InterruptOwner = InterruptOwner {
+            task: msg.sender.index() as u32,
+            notification: irq,
+        };
+
+        match get_task_irqs(owner) {
+            Ok(irqs) => {
+                let plic = unsafe { &mut *PLIC_REGISTER_BLOCK };
+                for irq in irqs.iter() {
+                    plic.complete(0, irq.0.try_into().unwrap());
+                }
+
+                return Ok(());
+            }
+            Err(()) => return Err(Runtime(ExtIntCtrlError::IRQUnassigned)),
+        }
+    }
+}
+
+impl idol_runtime::NotificationHandler for ServerImpl {
+    // The PLIC is only interested in interrupt notifications from the kernel
+    fn current_notification_mask(&self) -> u32 {
+        return PLIC_IRQ;
+    }
+
+    // An interrupt has come in.
+    // NOTE: Currently, the driver assumes that all interrupts come in on
+    //       Context 0.
+    fn handle_notification(&mut self, _bits: u32) {
+        let plic = unsafe { &mut *PLIC_REGISTER_BLOCK };
+        loop {
+            let irq: u32 = match plic.claim(0) {
+                Some(irq) => core::primitive::u16::from(irq) as u32,
+                None => break,
+            };
+
+            // An error means an interrupt came in on a line that no task has
+            // ownership over.
+            let owner: (TaskId, u32) = match get_irq_owner(irq) {
+                Ok(owner) => owner,
+                Err(()) => continue,
+            };
+
+            let code = sys_post(owner.0, owner.1);
+
+            // The task that owns the line was restarted.
+            if code & FIRST_DEAD_CODE == FIRST_DEAD_CODE {
+                let new_task_id = TaskId::for_index_and_gen(
+                    owner.0 .0.into(),
+                    ((code & !FIRST_DEAD_CODE) as u8).into(),
+                );
+
+                // SAFETY: We already have the irq owner, so we know that this
+                // operation will succeed. No need to bother checking for errors.
+                unsafe {
+                    set_irq_owner(irq, (new_task_id, owner.1))
+                        .unwrap_unchecked();
+                };
+                sys_post(new_task_id, owner.1);
+            }
+        }
+
+        sys_irq_control(PLIC_IRQ, true);
+    }
+}
+
+#[export_name = "main"]
+fn main() -> ! {
+    let plic = unsafe { &mut *PLIC_REGISTER_BLOCK };
+    plic.set_threshold(0, Priority::highest());
+
+    // Zero all interrupt sources ...
+    for i in 1..1024 {
+        let priority = if irq_assigned(i) {
+            plic.unmask(0, i as usize);
+            Priority::from_bits(1)
+        } else {
+            Priority::never()
+        };
+
+        plic.set_priority(i as usize, priority);
+    }
+
+    let mut incoming = [0u8; idl::INCOMING_SIZE];
+
+    plic.set_threshold(0, Priority::never());
+    let mut server: ServerImpl = ServerImpl {};
+    sys_irq_control(PLIC_IRQ, true);
+    loop {
+        idol_runtime::dispatch_n(&mut incoming, &mut server);
+    }
+}
+
+// And the Idol bits
+mod idl {
+    use drv_ext_int_ctrl_api::ExtIntCtrlError;
+    include!(concat!(env!("OUT_DIR"), "/server_stub.rs"));
+}
+
+include!(concat!(env!("OUT_DIR"), "/plic_config.rs"));

--- a/idl/ext-int-ctrl.idol
+++ b/idl/ext-int-ctrl.idol
@@ -1,0 +1,35 @@
+Interface(
+    name: "ExtIntCtrl",
+    ops: {
+        "disable_int": (
+            doc: "Disables the selected interrupt",
+            args: {
+                "irq": (type: "u32"),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ExtIntCtrlError"),
+            ),
+        ),
+        "enable_int": (
+            doc: "Enables the selected interrupt",
+            args: {
+                "irq": (type: "u32"),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ExtIntCtrlError"),
+            ),
+        ),
+        "complete_int": (
+            doc: "Tells the driver to complete the interrupt",
+            args: {
+                "irq": (type: "u32"),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("ExtIntCtrlError"),
+            ),
+        ),
+    },
+)

--- a/lib/phash/src/lib.rs
+++ b/lib/phash/src/lib.rs
@@ -34,6 +34,58 @@ impl<'a, K: Copy + PerfectHash + PartialEq, V> PerfectHashMap<'a, K, V> {
         }
     }
 
+    #[inline(always)]
+    pub fn contains(&self, key: K) -> bool {
+        self.get(key).is_some()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
+        self.values.iter()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct MutablePerfectHashMap<'a, K, V> {
+    pub m: u32,
+    pub values: &'a mut [(K, V)],
+}
+
+impl<'a, K: Copy + PerfectHash + PartialEq, V> MutablePerfectHashMap<'a, K, V> {
+    /// Looks up a value in the table by key, returning `None` if the key was
+    /// not stored in the table.
+    #[inline(always)]
+    pub fn get(&self, key: K) -> Option<&V> {
+        if self.values.is_empty() {
+            return None;
+        }
+        let i = key.phash(self.m) % self.values.len();
+        if key == self.values[i].0 {
+            Some(&self.values[i].1)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    pub fn set(&mut self, key: K, val: V) -> Result<(), ()> {
+        if self.values.is_empty() {
+            return Err(());
+        }
+        let i = key.phash(self.m) % self.values.len();
+        if key == self.values[i].0 {
+            self.values[i].1 = val;
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    #[inline(always)]
+    pub fn contains(&self, key: K) -> bool {
+        self.get(key).is_some()
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
         self.values.iter()
     }

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -33,6 +33,7 @@ phash-gen = {path = "../../build/phash-gen"}
 
 [features]
 vectored-interrupts = []
+custom-interrupts = []
 
 [lib]
 test = false

--- a/sys/kern/build.rs
+++ b/sys/kern/build.rs
@@ -337,17 +337,6 @@ pub const HUBRIS_IRQ_TASK_LOOKUP: NestedPerfectHashMap::<abi::InterruptNum, abi:
     }
 
     if target.starts_with("riscv") {
-        writeln!(
-            file,
-            "\npub(crate) type Plic = riscv::plic::Plic<{:#X},{}>;",
-            kconfig.plic.0, kconfig.plic.1
-        )?;
-        writeln!(
-            file,
-            "\npub(crate) type PlicPriority = riscv::plic::Priority<{}>;",
-            kconfig.plic.1
-        )?;
-
         // TODO: This will eventually need to be changed so that the timer info
         //       doesn't have to be shoved into `chip.toml`.
         writeln!(file, "pub const MTIME: u64 = {};", kconfig.timer.0)?;
@@ -363,6 +352,5 @@ struct KernelConfig {
     tasks: Vec<abi::TaskDesc>,
     regions: Vec<abi::RegionDesc>,
     irqs: Vec<abi::Interrupt>,
-    plic: (u32, u32),
     timer: (u32, u32),
 }


### PR DESCRIPTION
External interrupts are now handled in userspace, using the `riscv-plic` driver. The kernel now handles interrupts that go directly to the kernel, meaning that interrupt lines reserved for platform usage (`mcause` >= 16) are now usable in the kernel.