### PR TITLE
riscv task linker scripts: Add .sdata input section to .data output section

### DIFF
--- a/build/riscv-task-link.x
+++ b/build/riscv-task-link.x
@@ -39,6 +39,7 @@ SECTIONS
     . = ALIGN(4);
     __sdata = .;
     *(.data .data.*);
+    *(.sdata .sdata.*);
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
     __edata = .;
   } > RAM AT>FLASH

--- a/build/riscv-task-rlink.x
+++ b/build/riscv-task-rlink.x
@@ -35,6 +35,7 @@ SECTIONS
     . = ALIGN(4);
     __sdata = .;
     *(.data .data.*);
+    *(.sdata .sdata.*);
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
     __edata = .;
   }

--- a/build/riscv-task-tlink.x
+++ b/build/riscv-task-tlink.x
@@ -39,6 +39,7 @@ SECTIONS
     . = ALIGN(4);
     __sdata = .;
     *(.data .data.*);
+    *(.sdata .sdata.*);
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
     __edata = .;
   } > RAM AT>FLASH


### PR DESCRIPTION
This change adds the input section .sdata to the output section .data in task linker scripts. This ensures that the virtual address for the section is in RAM and the physical address is in FLASH.

Without this change, .sdata section was being allocated a physical address in RAM with PROGBITS set causing the generated final.bin image to be bloated up to 1.5G.