### PR TITLE
Add support for the OpenTitan chip

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        build: [stm32f3, stm32f4, lpc55, stm32h743, stm32h753, gemini, gemini-rot, gimlet-b, sidecar, stm32g0, gimlet-rot, hifive1-revb, hifive-inventor]
+        build: [stm32f3, stm32f4, lpc55, stm32h743, stm32h753, gemini, gemini-rot, gimlet-b, sidecar, stm32g0, gimlet-rot, hifive1-revb, hifive-inventor, opentitan-earlgrey]
         include:
           - build: stm32g0
             app_name: demo-stm32g070-nucleo
@@ -87,6 +87,7 @@ jobs:
             app_name: demo-hifive-inventor
             app_toml: app/demo-hifive-inventor/app.toml
             target: riscv32imc-unkown-none-elf
+            image: default
           - build: opentitan-earlgrey 
             app_name: demo-opentitan-earlgrey
             app_toml: app/demo-opentitan-earlgrey/app.toml

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -87,6 +87,10 @@ jobs:
             app_name: demo-hifive-inventor
             app_toml: app/demo-hifive-inventor/app.toml
             target: riscv32imc-unkown-none-elf
+          - build: opentitan-earlgrey 
+            app_name: demo-opentitan-earlgrey
+            app_toml: app/demo-opentitan-earlgrey/app.toml
+            target: riscv32imc-unkown-none-elf
             image: default
 
           - os: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo-opentitan-earlgrey"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "cfg-if 0.1.10",
+ "kern",
+ "panic-halt",
+ "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv-rt",
+]
+
+[[package]]
 name = "demo-stm32f4-discovery"
 version = "0.1.0"
 dependencies = [
@@ -3553,6 +3565,16 @@ dependencies = [
  "num-traits",
  "userlib",
  "zerocopy",
+]
+
+[[package]]
+name = "task-worker"
+version = "0.1.0"
+dependencies = [
+ "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv-pseudo-atomics",
+ "riscv-semihosting",
+ "userlib",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,6 +3157,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "task-aontimer-demo"
+version = "0.1.0"
+dependencies = [
+ "drv-ot-aontimer",
+ "drv-riscv-plic-api",
+ "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv-pseudo-atomics",
+ "riscv-semihosting",
+ "userlib",
+]
+
+[[package]]
 name = "task-config"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,11 +3172,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 name = "task-aontimer-demo"
 version = "0.1.0"
 dependencies = [
+ "drv-ext-int-ctrl-api",
  "drv-ot-aontimer",
- "drv-riscv-plic-api",
  "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
+ "task-config",
  "userlib",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "drv-ot-aontimer"
+version = "0.1.0"
+dependencies = [
+ "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv-semihosting",
+ "userlib",
+ "zerocopy",
+]
+
+[[package]]
 name = "drv-riscv-plic-server"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,16 +3568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "task-worker"
-version = "0.1.0"
-dependencies = [
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "riscv-pseudo-atomics",
- "riscv-semihosting",
- "userlib",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +3735,17 @@ dependencies = [
  "lpc55-pac",
  "panic-halt",
  "panic-itm",
+ "panic-semihosting",
+]
+
+[[package]]
+name = "tests-opentitan-earlgrey"
+version = "0.1.0"
+dependencies = [
+ "build-util",
+ "cfg-if 0.1.10",
+ "kern",
+ "panic-halt",
  "panic-semihosting",
 ]
 

--- a/app/demo-opentitan-earlgrey/Cargo.toml
+++ b/app/demo-opentitan-earlgrey/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+edition = "2018"
+readme = "README.md"
+name = "demo-opentitan-earlgrey"
+version = "0.1.0"
+
+[features]
+#semihosting = ["kern/klog-semihosting-riscv"]
+
+[dependencies]
+cfg-if = "0.1.10"
+panic-halt = "0.2.0"
+riscv = "0.8.0"
+riscv-rt = "0.9.0"
+
+
+[dependencies.kern]
+path = "../../sys/kern"
+default-features = false
+features = [ "vectored-interrupts" ]
+
+[build-dependencies]
+build-util = {path = "../../build/util"}
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "demo-opentitan-earlgrey"
+test = false
+bench = false

--- a/app/demo-opentitan-earlgrey/Cargo.toml
+++ b/app/demo-opentitan-earlgrey/Cargo.toml
@@ -4,9 +4,6 @@ readme = "README.md"
 name = "demo-opentitan-earlgrey"
 version = "0.1.0"
 
-[features]
-#semihosting = ["kern/klog-semihosting-riscv"]
-
 [dependencies]
 cfg-if = "0.1.10"
 panic-halt = "0.2.0"

--- a/app/demo-opentitan-earlgrey/README.md
+++ b/app/demo-opentitan-earlgrey/README.md
@@ -1,0 +1,1 @@
+# opentitan demo application

--- a/app/demo-opentitan-earlgrey/app.toml
+++ b/app/demo-opentitan-earlgrey/app.toml
@@ -43,6 +43,11 @@ task-slots = ["ext_int_ctrl"]
 uses = ["aontimer"]
 stacksize = 512
 
+[tasks.aontimer.config]
+clock_frequency_hz = 200_000;
+bark_threshold_ticks = 2000;
+bite_threshold_ticks = 5000;
+
 [tasks.idle]
 name = "task-idle"
 priority = 5

--- a/app/demo-opentitan-earlgrey/app.toml
+++ b/app/demo-opentitan-earlgrey/app.toml
@@ -1,0 +1,51 @@
+name = "demo-opentitan-earlgrey"
+target = "riscv32imc-unknown-none-elf"
+board = "opentitan-earlgrey"
+chip = "../../chips/opentitan-earlgrey"
+stacksize = 896
+
+[kernel]
+name = "demo-opentitan-earlgrey"
+requires = {flash = 18048, ram = 4096}
+features = []
+
+[tasks.jefe]
+name = "task-jefe"
+priority = 0
+max-sizes = {flash = 9200, ram = 4096}
+start = true
+features = ["semihosting-riscv"]
+stacksize = 1536
+
+[tasks.ext_int_ctrl]
+name = "drv-riscv-plic"
+priority = 1
+max-sizes = { flash = 4096, ram = 2048 }
+start = true
+features = ["semihosting-riscv"]
+uses = ["plic"]
+interrupts = { "plic.irq" = 0x1 }
+
+[tasks.ext_int_ctrl.config]
+ints = [158]
+tasks = ['"aontimer"']
+notification = [1]
+base = 0x4800_0000
+pbits = 3
+
+[tasks.aontimer]
+name = "task-aontimer-demo"
+priority = 2
+max-sizes = {flash = 10672, ram = 1024}
+start = true
+features = ["semihosting-riscv"]
+task-slots = ["ext_int_ctrl"]
+uses = ["aontimer"]
+stacksize = 512
+
+[tasks.idle]
+name = "task-idle"
+priority = 5
+max-sizes = {flash = 256, ram = 256}
+stacksize = 256
+start = true

--- a/app/demo-opentitan-earlgrey/app.toml
+++ b/app/demo-opentitan-earlgrey/app.toml
@@ -18,7 +18,7 @@ features = ["semihosting-riscv"]
 stacksize = 1536
 
 [tasks.ext_int_ctrl]
-name = "drv-riscv-plic"
+name = "drv-riscv-plic-server"
 priority = 1
 max-sizes = { flash = 4096, ram = 2048 }
 start = true
@@ -44,9 +44,9 @@ uses = ["aontimer"]
 stacksize = 512
 
 [tasks.aontimer.config]
-clock_frequency_hz = 200_000;
-bark_threshold_ticks = 2000;
-bite_threshold_ticks = 5000;
+clock_frequency_hz = 200_000
+bark_threshold_ticks = 2000
+bite_threshold_ticks = 5000
 
 [tasks.idle]
 name = "task-idle"

--- a/app/demo-opentitan-earlgrey/build.rs
+++ b/app/demo-opentitan-earlgrey/build.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() {
+    build_util::expose_target_board();
+}

--- a/app/demo-opentitan-earlgrey/src/main.rs
+++ b/app/demo-opentitan-earlgrey/src/main.rs
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+extern crate riscv_rt;
+
+use riscv_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    // The opentitan requires enabling the timer and interrupts
+    // for mtime and mtimecmp to behave as expected
+    // See https://docs.opentitan.org/hw/ip/rv_timer/doc/
+    const OT_TIMER_CTRL: u32 = 0x4010_0004;
+    const OT_TIMER_INTR: u32 = 0x4010_0100;
+
+    // Enable mtime to count up
+    let timer = OT_TIMER_CTRL as *mut u32;
+    unsafe {
+        *timer |= 1;
+    };
+
+    // Enable interrupts when mtime passes mtimecmp
+    let intr = OT_TIMER_INTR as *mut u32;
+    unsafe {
+        *intr |= 1;
+    };
+
+    // TODO this will need to change when run on actual hardware
+    const MTIMECMP: u32 = 1000;
+
+    unsafe { kern::startup::start_kernel(MTIMECMP) }
+}

--- a/app/demo-opentitan-earlgrey/src/main.rs
+++ b/app/demo-opentitan-earlgrey/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> ! {
     // for mtime and mtimecmp to behave as expected
     // See https://docs.opentitan.org/hw/ip/rv_timer/doc/
     const OT_TIMER_CTRL: u32 = 0x4010_0004;
-    const OT_TIMER_INTR: u32 = 0x4010_0100;
+    const OT_TIMER_INTR: u32 = 0x4010_0114;
 
     // Enable mtime to count up
     let timer = OT_TIMER_CTRL as *mut u32;

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -180,7 +180,10 @@ pub fn config(
             Ok(Some(flash))
         }
         _ => {
-            eprintln!("Warning: unrecognized board '{}', won't know how to flash.", board);
+            eprintln!(
+                "Warning: unrecognized board '{}', won't know how to flash.",
+                board
+            );
             Ok(None)
         }
     }

--- a/build/xtask/src/flash.rs
+++ b/build/xtask/src/flash.rs
@@ -164,7 +164,7 @@ pub fn config(
         | "nucleo-h753zi" | "stm32h7b3i-dk" | "gemini-bu-1" | "gimletlet-1"
         | "gimletlet-2" | "gimlet-a" | "gimlet-b" | "psc-1" | "sidecar-1"
         | "stm32g031" | "stm32g070" | "stm32g0b1" | "hifive-inventor"
-        | "hifive1-revb" => {
+        | "hifive1-revb" | "opentitan-earlgrey" => {
             let cfg = FlashProgramConfig::new(chip_dir.join("openocd.cfg"));
 
             let mut flash = FlashConfig::new(FlashProgram::OpenOcd(cfg));
@@ -180,7 +180,7 @@ pub fn config(
             Ok(Some(flash))
         }
         _ => {
-            eprintln!("Warning: unrecognized board, won't know how to flash.");
+            eprintln!("Warning: unrecognized board '{}', won't know how to flash.", board);
             Ok(None)
         }
     }

--- a/chips/fe310-g002/qemu.sh
+++ b/chips/fe310-g002/qemu.sh
@@ -1,1 +1,1 @@
-qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.bin -semihosting -semihosting-config enable=on,userspace=on
+qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.ihex -semihosting -semihosting-config enable=on,userspace=on

--- a/chips/fe310-g003/qemu.sh
+++ b/chips/fe310-g003/qemu.sh
@@ -1,1 +1,1 @@
-qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.bin -semihosting -semihosting-config enable=on,userspace=on
+qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.ihex -semihosting -semihosting-config enable=on,userspace=on

--- a/chips/opentitan-earlgrey/chip.toml
+++ b/chips/opentitan-earlgrey/chip.toml
@@ -1,0 +1,32 @@
+# These address are taken from the qemu opentitan machine
+# https://github.com/qemu/qemu/blob/master/hw/riscv/opentitan.c#L32
+
+[gpio0]
+address = 0x4004_0000
+size = 0x1000
+
+[uart0]
+address = 0x4000_0000
+size = 0x1000
+
+[aontimer]
+address = 0x4047_0000
+size = 0x1000
+interrupts = { bark = 158 }
+
+[plic]
+address = 0x4800_0000
+size = 0x0400_4004 
+interrupts = { irq = 11 }
+
+[timer]
+address = 0x4010_0000
+size = 0x1000
+
+[mtime]
+address = 0x4010_0110
+size = 0
+
+[mtimecmp]
+address = 0x4010_0118
+size = 0

--- a/chips/opentitan-earlgrey/memory.toml
+++ b/chips/opentitan-earlgrey/memory.toml
@@ -1,0 +1,12 @@
+[[flash]]
+address = 0x2000_0000
+size = 0x8_0000 
+read = true
+execute = true
+
+[[ram]]
+address = 0x1000_0000
+size = 0x1_0000 
+read = true
+write = true
+execute = false  # let's assume XN until proven otherwise

--- a/chips/opentitan-earlgrey/openocd.cfg
+++ b/chips/opentitan-earlgrey/openocd.cfg
@@ -1,0 +1,4 @@
+source [find mem_helper.tcl]
+# hack for humility to recognize "find target/opentitan-earlgrey"
+
+# TODO, once running on an FPGA will need to sort this out

--- a/chips/opentitan-earlgrey/openocd.gdb
+++ b/chips/opentitan-earlgrey/openocd.gdb
@@ -1,0 +1,8 @@
+target extended-remote :3333
+
+# print demangled symbols
+set confirm off
+set print asm-demangle on
+
+# set backtrace limit to not have infinite backtrace loops
+set backtrace limit 32

--- a/chips/opentitan-earlgrey/qemu.sh
+++ b/chips/opentitan-earlgrey/qemu.sh
@@ -1,0 +1,1 @@
+qemu-system-riscv32 -nographic -M opentitan -global ibex-timer.timebase-freq=1000000 -device loader,addr=0x20000000,cpu-num=0,file=final.ihex -semihosting -semihosting-config enable=on,userspace=on

--- a/drv/opentitan-aontimer/Cargo.toml
+++ b/drv/opentitan-aontimer/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "drv-ot-aontimer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+zerocopy = "0.6.1"
+
+[features]
+semihosting-riscv = [ "riscv-semihosting", "userlib/log-semihosting" ]
+log-null = ["userlib/log-null"]
+
+[target.'cfg(target_arch = "riscv32")'.dependencies]
+riscv = { version = "0.8" }
+riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", optional = true, features = ["default", "user-mode"] }

--- a/drv/opentitan-aontimer/src/lib.rs
+++ b/drv/opentitan-aontimer/src/lib.rs
@@ -51,16 +51,10 @@ impl AonTimer {
         unsafe {
             // This is just a counter, reset it to 0.
             (*inst.base_addr)[WDOG_COUNT_IDX] = 0;
-            // write 1 to clear any pending interrupts
-            (*inst.base_addr)[INTR_STATE_IDX] =
-                INTR_STATE_BITS_WKUP | INTR_STATE_BITS_WDOG;
-            (*inst.base_addr)[WDOG_BARK_THOLD_IDX] =
-                inst.ms_to_reg_count(bark_thold_ms)?;
-            if bark_thold_ms > bite_thold_ms {
-                return Err(());
-            }
-            (*inst.base_addr)[WDOG_BITE_THOLD_IDX] =
-                inst.ms_to_reg_count(bite_thold_ms)?;
+
+            inst.clear_wdt_irq();
+            inst.set_bark_thold(bark_thold_ms)?;
+            inst.set_bite_thold(bite_thold_ms)?;
         }
         Ok(inst)
     }
@@ -102,7 +96,7 @@ impl AonTimer {
     }
 
     //Sets the bark threshold in ms. If the configuration is locked, returns false.
-    pub fn set_bark_thold(&self, bark_thold_ms: u64) -> Result<(), ()> {
+    fn set_bark_thold(&self, bark_thold_ms: u64) -> Result<(), ()> {
         if !self.check_lock() {
             return Err(());
         }
@@ -114,7 +108,7 @@ impl AonTimer {
     }
 
     //Sets the bite threshold in ms. If the configuration is locked, returns false.
-    pub fn set_bite_thold(&self, bite_thold_ms: u64) -> Result<(), ()> {
+    fn set_bite_thold(&self, bite_thold_ms: u64) -> Result<(), ()> {
         if !self.check_lock() {
             return Err(());
         }
@@ -134,8 +128,7 @@ impl AonTimer {
 
     pub fn clear_wdt_irq(&self) {
         unsafe {
-            (*self.base_addr)[INTR_STATE_IDX] =
-                INTR_STATE_BITS_WKUP | INTR_STATE_BITS_WDOG;
+            (*self.base_addr)[INTR_STATE_IDX] = INTR_STATE_BITS_WDOG;
         }
     }
 

--- a/drv/opentitan-aontimer/src/lib.rs
+++ b/drv/opentitan-aontimer/src/lib.rs
@@ -1,0 +1,141 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+
+use core::ptr::slice_from_raw_parts_mut;
+
+const WDOG_REGWEN_IDX: usize = 4;
+const WDOG_CTRL_IDX: usize = 5;
+const WDOG_BARK_THOLD_IDX: usize = 6;
+const WDOG_BITE_THOLD_IDX: usize = 7;
+const WDOG_COUNT_IDX: usize = 8;
+const INTR_STATE_IDX: usize = 9;
+
+// The OpenTitan Always-On Timer is a counter that increments. If the counter
+// reaches a configurable threshold, it will emit an interrupt signal, called the
+// "bark". If the counter reaches a second configurable threshold, it will reset
+// the system, called the "bite".
+// Enabling the AON Timer before setting a bite threshold causes the system to
+// immediately reset.
+pub struct AonTimer {
+    base_addr: *mut [u32],
+    clock_freq_hz: u32,
+    pub bark_cb: Option<fn()>,
+}
+
+impl AonTimer {
+    // Initialize a new watchdog driver device with the specified base address,
+    // clock frequency (in Hz), and the bark/bite thresholds (both in ms).
+    // If the bark threshold > bite threshold, the bite threshold is set to
+    // the bark threshold.
+    pub fn new(
+        base_addr: u32,
+        clock_freq_hz: u32,
+        bark_thold_ms: u64,
+        bite_thold_ms: u64,
+        bark_cb: Option<fn()>,
+    ) -> Result<Self, ()> {
+        let inst = AonTimer {
+            base_addr: slice_from_raw_parts_mut(base_addr as *mut u32, 12),
+            clock_freq_hz,
+            bark_cb,
+        };
+        unsafe {
+            (*inst.base_addr)[WDOG_COUNT_IDX] = 0;
+            (*inst.base_addr)[INTR_STATE_IDX] = 0b11;
+            (*inst.base_addr)[WDOG_BARK_THOLD_IDX] = inst.ms_to_reg_count(bark_thold_ms)?;
+            if bark_thold_ms > bite_thold_ms {
+                return Err(());
+            }
+            (*inst.base_addr)[WDOG_BITE_THOLD_IDX] = inst.ms_to_reg_count(bite_thold_ms)?;
+        }
+        Ok(inst)
+    }
+
+    //Disable the watchdog timer. If the configuration is locked, returns false.
+    pub fn disable(&self) -> Result<(), ()> {
+        if !self.check_lock() {
+            return Err(());
+        }
+        unsafe {
+            (*self.base_addr)[WDOG_CTRL_IDX] = 0;
+        }
+        Ok(())
+    }
+
+    //Enables the watchdog timer. If the configuration is locked, returns false.
+    pub fn enable(&self) -> Result<(), ()> {
+        if !self.check_lock() {
+            return Err(());
+        }
+        unsafe {
+            (*self.base_addr)[WDOG_CTRL_IDX] |= 1;
+        }
+        Ok(())
+    }
+
+    //Enables the watchdog timer, then locks the configuration. If the
+    // configuration is already locked, returns false.
+    pub fn enable_and_lock(&self) -> Result<(), ()>{
+        if !self.check_lock() {
+            return Err(());
+        }
+        unsafe {
+            (*self.base_addr)[WDOG_CTRL_IDX] |= 1;
+            (*self.base_addr)[WDOG_REGWEN_IDX] = 0;
+        }
+        Ok(())
+    }
+
+    //Sets the bark threshold in ms. If the configuration is locked, returns false.
+    pub fn set_bark_thold(&self, bark_thold_ms: u64) -> Result<(), ()>{
+        if !self.check_lock() {
+            return Err(());
+        }
+        unsafe {
+            (*self.base_addr)[WDOG_BARK_THOLD_IDX] =
+                self.ms_to_reg_count(bark_thold_ms)?;
+        }
+        Ok(())
+    }
+
+    //Sets the bite threshold in ms. If the configuration is locked, returns false.
+    pub fn set_bite_thold(&self, bite_thold_ms: u64) -> Result<(), ()> {
+        if !self.check_lock() {
+            return Err(());
+        }
+        unsafe {
+            (*self.base_addr)[WDOG_BITE_THOLD_IDX] =
+                self.ms_to_reg_count(bite_thold_ms)?;
+        }
+        Ok(())
+    }
+
+    //Pets the watchdog, i.e. resets the count down to 0.
+    pub fn feed_sacrifice(&self) {
+        unsafe {
+            (*self.base_addr)[WDOG_COUNT_IDX] = 0;
+        }
+    }
+
+    pub fn clear_wdt_irq(&self) {
+        unsafe {
+            (*self.base_addr)[INTR_STATE_IDX] |= 0x2;
+        }
+    }
+
+    //Checks whether the configuration is locked.
+    #[inline(always)]
+    fn check_lock(&self) -> bool {
+        unsafe { (*self.base_addr)[WDOG_REGWEN_IDX] == 1 }
+    }
+
+    // Converts  milliseconds to an appropriate count in the register.
+    // If the result is greater than max int, the value is saturated to max int.
+    fn ms_to_reg_count(&self, ms: u64) -> Result<u32, ()> {
+        let mut time: u64 = ms * ((self.clock_freq_hz / 1000) as u64);
+        time.try_into().map_err(|_e| ())
+    }
+}

--- a/drv/opentitan-aontimer/src/lib.rs
+++ b/drv/opentitan-aontimer/src/lib.rs
@@ -52,12 +52,15 @@ impl AonTimer {
             // This is just a counter, reset it to 0.
             (*inst.base_addr)[WDOG_COUNT_IDX] = 0;
             // write 1 to clear any pending interrupts
-            (*inst.base_addr)[INTR_STATE_IDX] = INTR_STATE_BITS_WKUP | INTR_STATE_BITS_WDOG;
-            (*inst.base_addr)[WDOG_BARK_THOLD_IDX] = inst.ms_to_reg_count(bark_thold_ms)?;
+            (*inst.base_addr)[INTR_STATE_IDX] =
+                INTR_STATE_BITS_WKUP | INTR_STATE_BITS_WDOG;
+            (*inst.base_addr)[WDOG_BARK_THOLD_IDX] =
+                inst.ms_to_reg_count(bark_thold_ms)?;
             if bark_thold_ms > bite_thold_ms {
                 return Err(());
             }
-            (*inst.base_addr)[WDOG_BITE_THOLD_IDX] = inst.ms_to_reg_count(bite_thold_ms)?;
+            (*inst.base_addr)[WDOG_BITE_THOLD_IDX] =
+                inst.ms_to_reg_count(bite_thold_ms)?;
         }
         Ok(inst)
     }
@@ -87,7 +90,7 @@ impl AonTimer {
 
     //Enables the watchdog timer, then locks the configuration. If the
     // configuration is already locked, returns false.
-    pub fn enable_and_lock(&self) -> Result<(), ()>{
+    pub fn enable_and_lock(&self) -> Result<(), ()> {
         if !self.check_lock() {
             return Err(());
         }
@@ -99,7 +102,7 @@ impl AonTimer {
     }
 
     //Sets the bark threshold in ms. If the configuration is locked, returns false.
-    pub fn set_bark_thold(&self, bark_thold_ms: u64) -> Result<(), ()>{
+    pub fn set_bark_thold(&self, bark_thold_ms: u64) -> Result<(), ()> {
         if !self.check_lock() {
             return Err(());
         }
@@ -131,7 +134,8 @@ impl AonTimer {
 
     pub fn clear_wdt_irq(&self) {
         unsafe {
-            (*self.base_addr)[INTR_STATE_IDX] = INTR_STATE_BITS_WKUP | INTR_STATE_BITS_WDOG;
+            (*self.base_addr)[INTR_STATE_IDX] =
+                INTR_STATE_BITS_WKUP | INTR_STATE_BITS_WDOG;
         }
     }
 

--- a/drv/opentitan-aontimer/src/lib.rs
+++ b/drv/opentitan-aontimer/src/lib.rs
@@ -135,7 +135,7 @@ impl AonTimer {
     // Converts  milliseconds to an appropriate count in the register.
     // If the result is greater than max int, the value is saturated to max int.
     fn ms_to_reg_count(&self, ms: u64) -> Result<u32, ()> {
-        let mut time: u64 = ms * ((self.clock_freq_hz / 1000) as u64);
+        let time: u64 = ms * ((self.clock_freq_hz / 1000) as u64);
         time.try_into().map_err(|_e| ())
     }
 }

--- a/task/aontimer-demo/Cargo.toml
+++ b/task/aontimer-demo/Cargo.toml
@@ -9,6 +9,10 @@ drv-ot-aontimer = {path = "../../drv/opentitan-aontimer", features= ["semihostin
 drv-ext-int-ctrl-api = {path = "../../drv/ext-int-ctrl-api"}
 task-config = {path = "../../lib/task-config"}
 
+[build-dependencies]
+task-config = {path = "../../lib/task-config"}
+
+
 [features]
 semihosting-riscv = [ "riscv-semihosting", "userlib/log-semihosting" ]
 log-null = ["userlib/log-null"]

--- a/task/aontimer-demo/Cargo.toml
+++ b/task/aontimer-demo/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 [dependencies]
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 drv-ot-aontimer = {path = "../../drv/opentitan-aontimer", features= ["semihosting-riscv"]}
-drv-riscv-plic-api = {path = "../../drv/riscv-plic-api"}
+drv-ext-int-ctrl-api = {path = "../../drv/ext-int-ctrl-api"}
+task-config = {path = "../../lib/task-config"}
 
 [features]
 semihosting-riscv = [ "riscv-semihosting", "userlib/log-semihosting" ]

--- a/task/aontimer-demo/Cargo.toml
+++ b/task/aontimer-demo/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "task-aontimer-demo"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+drv-ot-aontimer = {path = "../../drv/opentitan-aontimer", features= ["semihosting-riscv"]}
+drv-riscv-plic-api = {path = "../../drv/riscv-plic-api"}
+
+[features]
+semihosting-riscv = [ "riscv-semihosting", "userlib/log-semihosting" ]
+log-null = ["userlib/log-null"]
+
+[target.'cfg(target_arch = "riscv32")'.dependencies]
+riscv = { version = "0.8" }
+riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", optional = true, features = ["default", "user-mode"] }
+riscv-pseudo-atomics = { git = "https://github.com/rivosinc/riscv-psuedo-atomics", branch = "rivos/main", features = ["default", "user-mode"] }
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "task-aontimer-demo"
+test = false
+bench = false

--- a/task/aontimer-demo/build.rs
+++ b/task/aontimer-demo/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 task_config::task_config! {
     #[allow(dead_code)]
     clock_frequency_hz: u32,

--- a/task/aontimer-demo/build.rs
+++ b/task/aontimer-demo/build.rs
@@ -1,0 +1,12 @@
+task_config::task_config!{
+    #[allow(dead_code)]
+    clock_frequency_hz: u32,
+    bark_threshold_ticks: u64,
+    bite_threshold_ticks: u64,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    assert!(TASK_CONFIG.bark_threshold_ticks < TASK_CONFIG.bite_threshold_ticks, "Bark threshold must be less than the bite threshold");
+    Ok(())
+}
+

--- a/task/aontimer-demo/build.rs
+++ b/task/aontimer-demo/build.rs
@@ -1,4 +1,4 @@
-task_config::task_config!{
+task_config::task_config! {
     #[allow(dead_code)]
     clock_frequency_hz: u32,
     bark_threshold_ticks: u64,
@@ -6,7 +6,9 @@ task_config::task_config!{
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    assert!(TASK_CONFIG.bark_threshold_ticks < TASK_CONFIG.bite_threshold_ticks, "Bark threshold must be less than the bite threshold");
+    assert!(
+        TASK_CONFIG.bark_threshold_ticks < TASK_CONFIG.bite_threshold_ticks,
+        "Bark threshold must be less than the bite threshold"
+    );
     Ok(())
 }
-

--- a/task/aontimer-demo/src/main.rs
+++ b/task/aontimer-demo/src/main.rs
@@ -6,19 +6,23 @@
 #![no_main]
 
 use drv_ot_aontimer::*;
-use drv_riscv_plic_api::*;
+use drv_ext_int_ctrl_api::*;
 use userlib::*;
 
 task_slot!(INT_CONTROLLER, ext_int_ctrl);
+
+task_config::task_config!{
+    clock_frequency_hz: u32,
+    bark_threshold_ticks: u64,
+    bite_threshold_ticks: u64,
+}
 
 //TODO should be replaced by build time constants
 // see jira https://rivosinc.atlassian.net/browse/SW-530
 const AONTIMER_BARK_NOTIFICATION: u32 = 0x1;
 const AONTIMER_TIME_NOTIFICATION: u32 = 0x2;
 
-const BARK_INT: u32 = 0;
-
-fn sleep_and_listen(timer: &AonTimer) {
+fn sleep_and_listen(timer: &AonTimer, int_ctrl: &ExtIntCtrl) {
     sys_log!("Sleeping...");
     let alarm = sys_get_timer().now;
     sys_set_timer(Some(alarm + 1000), AONTIMER_TIME_NOTIFICATION);
@@ -29,6 +33,7 @@ fn sleep_and_listen(timer: &AonTimer) {
             TaskId::KERNEL,
         )
         .unwrap();
+        int_ctrl.complete_int(AONTIMER_BARK_NOTIFICATION).unwrap();
         if result.operation & AONTIMER_BARK_NOTIFICATION != 0x0 {
             sys_log!("{}", sys_get_timer().now);
             //reset the interrupt
@@ -46,34 +51,31 @@ fn sleep_and_listen(timer: &AonTimer) {
 
 #[export_name = "main"]
 fn main() -> ! {
-    let int_ctrl = RiscvIntCtrl::from(INT_CONTROLLER.get_task_id());
-
-    int_ctrl.disable_int(BARK_INT).unwrap();
+    let int_ctrl = ExtIntCtrl::from(INT_CONTROLLER.get_task_id());
 
     //TODO change to const read from chip config
     //see jira https://rivosinc.atlassian.net/browse/SW-431
     const AONTIMER_BASE: u32 = 0x4047_0000;
-    const AONTIMER_FREQ: u32 = 200_000;
     sys_log!("Restarted...");
 
-    int_ctrl.enable_int(BARK_INT).unwrap();
+    int_ctrl.enable_int(AONTIMER_BARK_NOTIFICATION).unwrap();
 
     let timer = AonTimer::new(
         AONTIMER_BASE,
-        AONTIMER_FREQ,
-        2000,
-        5000,
+        TASK_CONFIG.clock_frequency_hz,
+        TASK_CONFIG.bark_threshold_ticks,
+        TASK_CONFIG.bite_threshold_ticks,
         Some(|| {
             sys_log!("Bark!");
         }),
     ).unwrap();
 
-    timer.enable();
+    timer.enable().unwrap();
     loop {
         //Two things need to be queried:
         // 1. When the timer expires, we should feed the watchdog.
         // 2. When the bark interrupt is raised, handle it.
-        sleep_and_listen(&timer);
+        sleep_and_listen(&timer, &int_ctrl);
         sys_log!("Feeding...");
         timer.feed_sacrifice();
     }

--- a/task/aontimer-demo/src/main.rs
+++ b/task/aontimer-demo/src/main.rs
@@ -5,13 +5,13 @@
 #![no_std]
 #![no_main]
 
-use drv_ot_aontimer::*;
 use drv_ext_int_ctrl_api::*;
+use drv_ot_aontimer::*;
 use userlib::*;
 
 task_slot!(INT_CONTROLLER, ext_int_ctrl);
 
-task_config::task_config!{
+task_config::task_config! {
     clock_frequency_hz: u32,
     bark_threshold_ticks: u64,
     bite_threshold_ticks: u64,
@@ -68,7 +68,8 @@ fn main() -> ! {
         Some(|| {
             sys_log!("Bark!");
         }),
-    ).unwrap();
+    )
+    .unwrap();
 
     timer.enable().unwrap();
     loop {

--- a/task/aontimer-demo/src/main.rs
+++ b/task/aontimer-demo/src/main.rs
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+use drv_ot_aontimer::*;
+use drv_riscv_plic_api::*;
+use userlib::*;
+
+task_slot!(INT_CONTROLLER, ext_int_ctrl);
+
+//TODO should be replaced by build time constants
+// see jira https://rivosinc.atlassian.net/browse/SW-530
+const AONTIMER_BARK_NOTIFICATION: u32 = 0x1;
+const AONTIMER_TIME_NOTIFICATION: u32 = 0x2;
+
+const BARK_INT: u32 = 0;
+
+fn sleep_and_listen(timer: &AonTimer) {
+    sys_log!("Sleeping...");
+    let alarm = sys_get_timer().now;
+    sys_set_timer(Some(alarm + 1000), AONTIMER_TIME_NOTIFICATION);
+    loop {
+        let result = sys_recv_closed(
+            &mut [],
+            AONTIMER_BARK_NOTIFICATION | AONTIMER_TIME_NOTIFICATION,
+            TaskId::KERNEL,
+        )
+        .unwrap();
+        if result.operation & AONTIMER_BARK_NOTIFICATION != 0x0 {
+            sys_log!("{}", sys_get_timer().now);
+            //reset the interrupt
+            if timer.bark_cb.is_some() {
+                sys_log!("calling back");
+                (timer.bark_cb.unwrap())();
+            }
+        }
+        if result.operation & AONTIMER_TIME_NOTIFICATION != 0x0 {
+            // Comment the following line of code to recieve the bark, and then be forced reset.
+            return; //You've woken up
+        }
+    }
+}
+
+#[export_name = "main"]
+fn main() -> ! {
+    let int_ctrl = RiscvIntCtrl::from(INT_CONTROLLER.get_task_id());
+
+    int_ctrl.disable_int(BARK_INT).unwrap();
+
+    //TODO change to const read from chip config
+    //see jira https://rivosinc.atlassian.net/browse/SW-431
+    const AONTIMER_BASE: u32 = 0x4047_0000;
+    const AONTIMER_FREQ: u32 = 200_000;
+    sys_log!("Restarted...");
+
+    int_ctrl.enable_int(BARK_INT).unwrap();
+
+    let timer = AonTimer::new(
+        AONTIMER_BASE,
+        AONTIMER_FREQ,
+        2000,
+        5000,
+        Some(|| {
+            sys_log!("Bark!");
+        }),
+    ).unwrap();
+
+    timer.enable();
+    loop {
+        //Two things need to be queried:
+        // 1. When the timer expires, we should feed the watchdog.
+        // 2. When the bark interrupt is raised, handle it.
+        sleep_and_listen(&timer);
+        sys_log!("Feeding...");
+        timer.feed_sacrifice();
+    }
+}

--- a/test/tests-opentitan-earlgrey/Cargo.toml
+++ b/test/tests-opentitan-earlgrey/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+edition = "2018"
+readme = "README.md"
+name = "tests-opentitan-earlgrey"
+version = "0.1.0"
+
+[dependencies]
+cfg-if = "0.1.10"
+panic-halt = { version = "0.2.0", optional = true }
+panic-semihosting = { version = "0.5.3", optional = true }
+
+[dependencies.kern]
+path = "../../sys/kern"
+default-features = false
+
+[build-dependencies]
+build-util = {path = "../../build/util"}
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "tests-opentitan-earlgrey"
+path = "../../app/demo-opentitan-earlgrey/src/main.rs"
+test = false
+bench = false

--- a/test/tests-opentitan-earlgrey/app.toml
+++ b/test/tests-opentitan-earlgrey/app.toml
@@ -1,0 +1,53 @@
+name = "tests-opentitan-earlgrey"
+target = "riscv32imc-unknown-none-elf"
+board = "opentitan-earlgrey"
+stacksize = 2048
+chip = "../../chips/opentitan-earlgrey"
+
+[kernel]
+name = "demo-opentitan-earlgrey"
+requires = {flash = 16384, ram = 3232}
+features = []
+
+[tasks.runner]
+name = "test-runner"
+priority = 0
+max-sizes = {flash = 16384, ram = 4096}
+start = true
+features = ["semihosting"]
+
+[tasks.suite]
+name = "test-suite"
+priority = 2
+max-sizes = {flash = 65536, ram = 4096}
+start = true
+features = ["semihosting"]
+task-slots = ["idol", "assist", "suite", "runner"]
+
+# This block is used to test the task_config macro
+[tasks.suite.config]
+foo = '"Hello, world"'
+bar = 42
+baz = [1, 2, 3, 4]
+tup = [[1, true], [2, true], [3, false]]
+
+[tasks.assist]
+name = "test-assist"
+priority = 1
+max-sizes = {flash = 16384, ram = 4096}
+start = true
+features = ["semihosting"]
+
+[tasks.idol]
+name = "test-idol-server"
+priority = 1
+max-sizes = {flash = 8192, ram = 1024}
+stacksize = 1024
+start = true
+
+[tasks.idle]
+name = "task-idle"
+priority = 3
+max-sizes = {flash = 256, ram = 256}
+stacksize = 256
+start = true


### PR DESCRIPTION
This PR includes a OpenTitan Demo App which utilizes the AON Timer and the hubris test suite for OpenTitan.
It also includes a change to `qemu.sh` to support larger images.

This will not run on upstream qemu, but with Tylers updated version. https://gitlab.ba.rivosinc.com/rv/sw/ext/qemu/-/tree/dev/tkng/opentitan.