### PR TITLE
build: Add linker scripts for rv64

### DIFF
--- a/build/riscv64-kernel-link.x
+++ b/build/riscv64-kernel-link.x
@@ -1,0 +1,176 @@
+INCLUDE memory.x
+
+PROVIDE(_stext = ORIGIN(REGION_TEXT));
+PROVIDE(_stack_start = ORIGIN(REGION_STACK) + LENGTH(REGION_STACK));
+PROVIDE(_max_hart_id = 0);
+PROVIDE(_hart_stack_size = 896);
+PROVIDE(_heap_size = 0);
+
+PROVIDE(UserSoft = DefaultHandler);
+PROVIDE(SupervisorSoft = DefaultHandler);
+PROVIDE(MachineSoft = DefaultHandler);
+PROVIDE(UserTimer = DefaultHandler);
+PROVIDE(SupervisorTimer = DefaultHandler);
+PROVIDE(MachineTimer = DefaultHandler);
+PROVIDE(UserExternal = DefaultHandler);
+PROVIDE(SupervisorExternal = DefaultHandler);
+PROVIDE(MachineExternal = DefaultHandler);
+
+PROVIDE(DefaultHandler = DefaultInterruptHandler);
+PROVIDE(ExceptionHandler = DefaultExceptionHandler);
+
+/* # Pre-initialization function */
+/* If the user overrides this using the `#[pre_init]` attribute or by creating a `__pre_init` function,
+   then the function this points to will be called before the RAM is initialized. */
+PROVIDE(__pre_init = default_pre_init);
+
+/* A PAC/HAL defined routine that should initialize custom interrupt controller if needed. */
+PROVIDE(_setup_interrupts = default_setup_interrupts);
+
+/* # Multi-processing hook function
+   fn _mp_hook() -> bool;
+
+   This function is called from all the harts and must return true only for one hart,
+   which will perform memory initialization. For other harts it must return false
+   and implement wake-up in platform-dependent way (e.g. after waiting for a user interrupt).
+*/
+PROVIDE(_mp_hook = default_mp_hook);
+
+/* # Start trap function override
+  By default uses the riscv crates default trap handler
+  but by providing the `_start_trap` symbol external crates can override.
+*/
+PROVIDE(_start_trap = default_start_trap);
+
+SECTIONS
+{
+  .text.dummy (NOLOAD) :
+  {
+    /* This section is intended to make _stext address work */
+    . = ABSOLUTE(_stext);
+  } > REGION_TEXT
+
+  .text _stext :
+  {
+    /* Put reset handler first in .text section so it ends up as the entry */
+    /* point of the program. */
+    KEEP(*(.init));
+    KEEP(*(.init.rust));
+    . = ALIGN(8);
+    (*(.trap));
+    (*(.trap.rust));
+
+    *(.text .text.*);
+  } > REGION_TEXT
+
+  .rodata : ALIGN(8)
+  {
+    *(.srodata .srodata.*);
+    *(.rodata .rodata.*);
+
+    /* 8-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
+    . = ALIGN(8);
+  } > REGION_RODATA
+
+  .data : ALIGN(8)
+  {
+    _sidata = LOADADDR(.data);
+    _sdata = .;
+    /* Must be called __global_pointer$ for linker relaxations to work. */
+    PROVIDE(__global_pointer$ = . + 0x800);
+    *(.sdata .sdata.* .sdata2 .sdata2.*);
+    *(.data .data.*);
+    . = ALIGN(8);
+    _edata = .;
+  } > REGION_DATA AT > REGION_RODATA
+
+  .bss (NOLOAD) :
+  {
+    _sbss = .;
+    *(.sbss .sbss.* .bss .bss.*);
+    . = ALIGN(8);
+    _ebss = .;
+  } > REGION_BSS
+
+  /* fictitious region that represents the memory available for the heap */
+  .heap (NOLOAD) :
+  {
+    _sheap = .;
+    . += _heap_size;
+    . = ALIGN(8);
+    _eheap = .;
+  } > REGION_HEAP
+
+  /* fictitious region that represents the memory available for the stack */
+  .stack (NOLOAD) :
+  {
+    _estack = .;
+    . = ABSOLUTE(_stack_start);
+    _sstack = .;
+  } > REGION_STACK
+
+  /* fake output .got section */
+  /* Dynamic relocations are unsupported. This section is only used to detect
+     relocatable code in the input files and raise an error if relocatable code
+     is found */
+  .got (INFO) :
+  {
+    KEEP(*(.got .got.*));
+  }
+
+  .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
+  .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
+}
+
+/* Do not exceed this mark in the error messages above                                    | */
+ASSERT(ORIGIN(REGION_TEXT) % 8 == 0, "
+ERROR(riscv-rt): the start of the REGION_TEXT must be 8-byte aligned");
+
+ASSERT(ORIGIN(REGION_RODATA) % 8 == 0, "
+ERROR(riscv-rt): the start of the REGION_RODATA must be 8-byte aligned");
+
+ASSERT(ORIGIN(REGION_DATA) % 8 == 0, "
+ERROR(riscv-rt): the start of the REGION_DATA must be 8-byte aligned");
+
+ASSERT(ORIGIN(REGION_HEAP) % 8 == 0, "
+ERROR(riscv-rt): the start of the REGION_HEAP must be 8-byte aligned");
+
+ASSERT(ORIGIN(REGION_TEXT) % 8 == 0, "
+ERROR(riscv-rt): the start of the REGION_TEXT must be 8-byte aligned");
+
+ASSERT(ORIGIN(REGION_STACK) % 8 == 0, "
+ERROR(riscv-rt): the start of the REGION_STACK must be 8-byte aligned");
+
+ASSERT(_stext % 8 == 0, "
+ERROR(riscv-rt): `_stext` must be 8-byte aligned");
+
+ASSERT(_sdata % 8 == 0 && _edata % 8 == 0, "
+BUG(riscv-rt): .data is not 8-byte aligned");
+
+ASSERT(_sidata % 8 == 0, "
+BUG(riscv-rt): the LMA of .data is not 8-byte aligned");
+
+ASSERT(_sbss % 8 == 0 && _ebss % 8 == 0, "
+BUG(riscv-rt): .bss is not 8-byte aligned");
+
+ASSERT(_sheap % 8 == 0, "
+BUG(riscv-rt): start of .heap is not 8-byte aligned");
+
+ASSERT(_stext + SIZEOF(.text) < ORIGIN(REGION_TEXT) + LENGTH(REGION_TEXT), "
+ERROR(riscv-rt): The .text section must be placed inside the REGION_TEXT region.
+Set _stext to an address smaller than 'ORIGIN(REGION_TEXT) + LENGTH(REGION_TEXT)'");
+
+ASSERT(SIZEOF(.stack) > (_max_hart_id + 1) * _hart_stack_size, "
+ERROR(riscv-rt): .stack section is too small for allocating stacks for all the harts.
+Consider changing `_max_hart_id` or `_hart_stack_size`.");
+
+ASSERT(SIZEOF(.got) == 0, "
+.got section detected in the input files. Dynamic relocations are not
+supported. If you are linking to C code compiled using the `gcc` crate
+then modify your build script to compile the C code _without_ the
+-fPIC flag. See the documentation of the `gcc::Config.fpic` method for
+details.");
+
+/* Do not exceed this mark in the error messages above                                    | */

--- a/build/riscv64-task-link.x
+++ b/build/riscv64-task-link.x
@@ -39,6 +39,7 @@ SECTIONS
     . = ALIGN(8);
     __sdata = .;
     *(.data .data.*);
+    *(.sdata .sdata.*);
     . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
     __edata = .;
   } > RAM

--- a/build/riscv64-task-link.x
+++ b/build/riscv64-task-link.x
@@ -1,0 +1,91 @@
+INCLUDE memory.x
+
+PROVIDE(_heap_size = 0);
+
+ENTRY(_start);
+
+SECTIONS
+{
+  PROVIDE(_stack_start = ORIGIN(STACK) + LENGTH(STACK));
+
+  /* ### .text */
+  .text : {
+    _stext = .;
+    *(.text.start*); /* try and pull start symbol to beginning */
+    *(.text .text.*);
+    . = ALIGN(8);
+    __etext = .;
+  } > RAM =0xdededede
+
+  /* ### .rodata */
+  .rodata : ALIGN(8)
+  {
+    *(.rodata .rodata.*);
+
+    /* 8-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
+    . = ALIGN(8);
+    __erodata = .;
+  } > RAM
+
+  /*
+   * Sections in RAM
+   *
+   * NOTE: the userlib runtime assumes that these sections
+   * are 8-byte aligned and padded to 8-byte boundaries.
+   */
+  .data : ALIGN(8) {
+    . = ALIGN(8);
+    __sdata = .;
+    *(.data .data.*);
+    . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
+    __edata = .;
+  } > RAM
+
+  /* LMA of .data */
+  __sidata = LOADADDR(.data);
+
+  .bss (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN(8);
+    __sbss = .;
+    *(.sbss .sbss* .bss .bss.*);
+    . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
+    __ebss = .;
+  } > RAM
+
+  .uninit (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN(8);
+    *(.uninit .uninit.*);
+    . = ALIGN(8);
+    /* Place the heap right after `.uninit` */
+    __sheap = .;
+  } > RAM
+
+  /* ## .got */
+  /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
+     the input files and raise an error if relocatable code is found */
+  .got (NOLOAD) :
+  {
+    KEEP(*(.got .got.*));
+  }
+
+  .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
+  .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
+
+  /* ## .task_slot_table */
+  /* Table of TaskSlot instances and their names. Used to resolve task
+     dependencies during packaging. */
+  .task_slot_table (INFO) : {
+    . = .;
+    KEEP(*(.task_slot_table));
+  }
+
+  /* ## .idolatry */
+  .idolatry (INFO) : {
+    . = .;
+    KEEP(*(.idolatry));
+  }
+}

--- a/build/riscv64-task-rlink.x
+++ b/build/riscv64-task-rlink.x
@@ -35,6 +35,7 @@ SECTIONS
     . = ALIGN(8);
     __sdata = .;
     *(.data .data.*);
+    *(.sdata .sdata.*);
     . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
     __edata = .;
   }

--- a/build/riscv64-task-rlink.x
+++ b/build/riscv64-task-rlink.x
@@ -1,0 +1,81 @@
+PROVIDE(_heap_size = 0);
+
+ENTRY(_start);
+
+SECTIONS
+{
+  /* ### .text */
+  .text : {
+    _stext = .;
+    *(.text.start*); /* try and pull start symbol to beginning */
+    *(.text .text.*);
+    . = ALIGN(8);
+    __etext = .;
+  }
+
+  /* ### .rodata */
+  .rodata : ALIGN(8)
+  {
+    *(.rodata .rodata.*);
+
+    /* 8-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
+    . = ALIGN(8);
+    __erodata = .;
+  }
+
+  /*
+   * Sections in RAM
+   *
+   * NOTE: the userlib runtime assumes that these sections
+   * are 8-byte aligned and padded to 8-byte boundaries.
+   */
+  .data : ALIGN(8) {
+    . = ALIGN(8);
+    __sdata = .;
+    *(.data .data.*);
+    . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
+    __edata = .;
+  }
+
+  .bss (NOLOAD) : ALIGN(8) {
+    . = ALIGN(8);
+    __sbss = .;
+    *(.sbss .sbss* .bss .bss.*);
+    . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
+    __ebss = .;
+  }
+
+  .uninit (NOLOAD) : ALIGN(8) {
+    . = ALIGN(8);
+    *(.uninit .uninit.*);
+    . = ALIGN(8);
+    /* Place the heap right after `.uninit` */
+    __sheap = .;
+  }
+
+  /* ## .got */
+  /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
+     the input files and raise an error if relocatable code is found */
+  .got (NOLOAD) : {
+    KEEP(*(.got .got.*));
+  }
+
+  .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
+  .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
+
+  /* ## .task_slot_table */
+  /* Table of TaskSlot instances and their names. Used to resolve task
+     dependencies during packaging. */
+  .task_slot_table (INFO) : {
+    . = .;
+    KEEP(*(.task_slot_table));
+  }
+
+  /* ## .idolatry */
+  .idolatry (INFO) : {
+    . = .;
+    KEEP(*(.idolatry));
+  }
+}

--- a/build/riscv64-task-tlink.x
+++ b/build/riscv64-task-tlink.x
@@ -39,6 +39,7 @@ SECTIONS
     . = ALIGN(8);
     __sdata = .;
     *(.data .data.*);
+    *(.sdata .sdata.*);
     . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
     __edata = .;
   } > RAM

--- a/build/riscv64-task-tlink.x
+++ b/build/riscv64-task-tlink.x
@@ -1,0 +1,91 @@
+INCLUDE memory.x
+
+PROVIDE(_heap_size = 0);
+
+ENTRY(_start);
+
+SECTIONS
+{
+  PROVIDE(_stack_start = ORIGIN(STACK) + LENGTH(STACK));
+
+  /* ### .text */
+  .text : {
+    _stext = .;
+    *(.text.start*); /* try and pull start symbol to beginning */
+    *(.text .text.*);
+    . = ALIGN(8);
+    __etext = .;
+  } > RAM =0xdededede
+
+  /* ### .rodata */
+  .rodata : ALIGN(8)
+  {
+    *(.rodata .rodata.*);
+
+    /* 8-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
+    . = ALIGN(8);
+    __erodata = .;
+  } > RAM
+
+  /*
+   * Sections in RAM
+   *
+   * NOTE: the userlib runtime assumes that these sections
+   * are 8-byte aligned and padded to 8-byte boundaries.
+   */
+  .data : ALIGN(8) {
+    . = ALIGN(8);
+    __sdata = .;
+    *(.data .data.*);
+    . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
+    __edata = .;
+  } > RAM
+
+  /* LMA of .data */
+  __sidata = LOADADDR(.data);
+
+  .bss (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN(8);
+    __sbss = .;
+    *(.sbss .sbss* .bss .bss.*);
+    . = ALIGN(8); /* 8-byte align the end (VMA) of this section */
+    __ebss = .;
+  } > RAM
+
+  .uninit (NOLOAD) : ALIGN(8)
+  {
+    . = ALIGN(8);
+    *(.uninit .uninit.*);
+    . = ALIGN(8);
+    /* Place the heap right after `.uninit` */
+    __sheap = .;
+  } > RAM
+
+  /* ## .got */
+  /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
+     the input files and raise an error if relocatable code is found */
+  .got (NOLOAD) :
+  {
+    KEEP(*(.got .got.*));
+  }
+
+  .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
+  .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
+
+  /* ## .task_slot_table */
+  /* Table of TaskSlot instances and their names. Used to resolve task
+     dependencies during packaging. */
+  .task_slot_table (INFO) : {
+    . = .;
+    KEEP(*(.task_slot_table));
+  }
+
+  /* ## .idolatry */
+  .idolatry (INFO) : {
+    . = .;
+    KEEP(*(.idolatry));
+  }
+}


### PR DESCRIPTION
This change copies over linker scripts from rv32 and updates them to ensure that everything is 8-byte aligned.