### PR TITLE
build/util: Extend check for riscv_no_atomics to rv64

### DIFF
--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -24,7 +24,7 @@ pub fn expose_cpu_info() {
         println!("cargo:rustc-cfg=armv7m");
     } else if target.starts_with("thumbv8m") {
         println!("cargo:rustc-cfg=armv8m");
-    } else if target.starts_with("riscv32") {
+    } else if target.starts_with("riscv") {
         target.truncate(target.find('-').unwrap());
         if !target.contains('a') && !target.contains('g') {
             eprintln!(


### PR DESCRIPTION
This change extends the check for riscv_no_atomics to include rv64. It also silences the error thrown by `expose_cpu_info` for lack of rv64 target check.