### PR TITLE
userlib: Move 32-bit struct members to end of struct

### DIFF
--- a/sys/userlib/src/arch/arm_m.rs
+++ b/sys/userlib/src/arch/arm_m.rs
@@ -218,11 +218,11 @@ pub(crate) unsafe extern "C" fn sys_send_stub(
                 adds r4, #{sysnum}
                 mov r11, r4
                 @ Load in args from the struct.
-                ldm r0!, {{r4-r7}}
-                ldm r0, {{r0-r2}}
-                mov r8, r0
-                mov r9, r1
-                mov r10, r2
+                ldm r0!, {{r5-r7}}
+                ldm r0!, {{r1-r4}}
+                mov r8, r1
+                mov r9, r2
+                mov r10, r3
 
                 @ To the kernel!
                 svc #0
@@ -246,7 +246,8 @@ pub(crate) unsafe extern "C" fn sys_send_stub(
                 @ Spill the registers we're about to use to pass stuff.
                 push {{r4-r11}}
                 @ Load in args from the struct.
-                ldm r0, {{r4-r10}}
+                ldm r0!, {{r5-r10}}
+                ldm r0, {{r4}}
                 @ Load the constant syscall number.
                 mov r11, {sysnum}
 
@@ -528,9 +529,10 @@ pub(crate) unsafe extern "C" fn sys_borrow_read_stub(
                 adds r4, #{sysnum}
                 mov r11, r4
                 @ Move register arguments into place.
-                ldm r0!, {{r4-r7}}
-                ldm r0, {{r0}}
-                mov r8, r0
+                ldm r0!, {{r5-r7}}
+                ldm r0!, {{r1}}
+                mov r8, r1
+                ldm r0!, {{r4}}
 
                 @ To the kernel!
                 svc #0
@@ -554,7 +556,8 @@ pub(crate) unsafe extern "C" fn sys_borrow_read_stub(
                 push {{r4-r8, r11}}
 
                 @ Move register arguments into place.
-                ldm r0, {{r4-r8}}
+                ldm r0!, {{r5-r8}}
+                ldm r0, {{r4}}
                 @ Load the constant syscall number.
                 mov r11, {sysnum}
 
@@ -597,9 +600,10 @@ pub(crate) unsafe extern "C" fn sys_borrow_write_stub(
                 adds r4, #{sysnum}
                 mov r11, r4
                 @ Move register arguments into place.
-                ldm r0!, {{r4-r7}}
-                ldr r0, [r0]
-                mov r8, r0
+                ldm r0!, {{r5-r7}}
+                ldm r0, {{r1}}
+                mov r8, r1
+                ldm r0!, {{r4}}
 
                 @ To the kernel!
                 svc #0
@@ -624,7 +628,8 @@ pub(crate) unsafe extern "C" fn sys_borrow_write_stub(
                 push {{r4-r8, r11}}
 
                 @ Move register arguments into place.
-                ldm r0, {{r4-r8}}
+                ldm r0!, {{r5-r8}}
+                ldm r0, {{r4}}
                 @ Load the constant syscall number.
                 mov r11, {sysnum}
 

--- a/sys/userlib/src/arch/riscv32.rs
+++ b/sys/userlib/src/arch/riscv32.rs
@@ -79,13 +79,13 @@ pub(crate) unsafe extern "C" fn sys_send_stub(
 ) -> RcLen {
     asm!("
         # Load in args from the struct.
-        lw a6, 6*4(a0)
-        lw a5, 5*4(a0)
-        lw a4, 4*4(a0)
-        lw a3, 3*4(a0)
-        lw a2, 2*4(a0)
-        lw a1, 1*4(a0)
-        lw a0, 0*4(a0)
+        lw a6, 5*4(a0)
+        lw a5, 4*4(a0)
+        lw a4, 3*4(a0)
+        lw a3, 2*4(a0)
+        lw a2, 1*4(a0)
+        lw a1, 0*4(a0)
+        lw a0, 6*4(a0)
 
         # Load the constant syscall number.
         li a7, {sysnum}
@@ -196,11 +196,11 @@ pub(crate) unsafe extern "C" fn sys_borrow_read_stub(
     asm!("
         # Move register arguments into place, in reverse order so that a0 is
         # loaded last when we're finished with it.
-        lw a4, 4*4(a0)
-        lw a3, 3*4(a0)
-        lw a2, 2*4(a0)
-        lw a1, 1*4(a0)
-        lw a0, 0*4(a0)
+        lw a4, 3*4(a0)
+        lw a3, 2*4(a0)
+        lw a2, 1*4(a0)
+        lw a1, 0*4(a0)
+        lw a0, 4*4(a0)
 
         # Load the constant syscall number.
         li a7, {sysnum}
@@ -225,11 +225,11 @@ pub(crate) unsafe extern "C" fn sys_borrow_write_stub(
     asm!("
         # Move register arguments into place, in reverse order so that a0 is
         # loaded last when we're finished with it.
-        lw a4, 4*4(a0)
-        lw a3, 3*4(a0)
-        lw a2, 2*4(a0)
-        lw a1, 1*4(a0)
-        lw a0, 0*4(a0)
+        lw a4, 3*4(a0)
+        lw a3, 2*4(a0)
+        lw a2, 1*4(a0)
+        lw a1, 0*4(a0)
+        lw a0, 4*4(a0)
 
         # Load the constant syscall number.
         li a7, {sysnum}

--- a/sys/userlib/src/lib.rs
+++ b/sys/userlib/src/lib.rs
@@ -146,13 +146,13 @@ pub fn sys_send(
 #[allow(dead_code)] // this gets used from asm
 #[repr(C)] // field order matters
 struct SendArgs<'a> {
-    packed_target_operation: u32,
     outgoing_ptr: *const u8,
     outgoing_len: usize,
     incoming_ptr: *mut u8,
     incoming_len: usize,
     lease_ptr: *const Lease<'a>,
     lease_len: usize,
+    packed_target_operation: u32,
 }
 
 /// Performs an "open" RECV that will accept messages from any task or
@@ -328,11 +328,11 @@ pub fn sys_borrow_read(
 
 #[repr(C)]
 struct BorrowReadArgs {
-    lender: u32,
     index: usize,
     offset: usize,
     dest: *mut u8,
     dest_len: usize,
+    lender: u32,
 }
 
 #[inline(always)]
@@ -354,11 +354,11 @@ pub fn sys_borrow_write(
 
 #[repr(C)]
 struct BorrowWriteArgs {
-    lender: u32,
     index: usize,
     offset: usize,
     src: *const u8,
     src_len: usize,
+    lender: u32,
 }
 
 #[inline(always)]


### PR DESCRIPTION
This change moves 32-bit struct members in syscall stack args structure to end of struct to ensure that the 64-bit (usize) struct members are properly aligned on a 64-bit system. ASM code in arm_m.rs and riscv32.rs is accordingly updated.

TEST=Ensured that rv32 still boots and tests pass for hifive-inventor on qemu.