### PR TITLE
Remove setting of `mpie`.

### DIFF
--- a/sys/kern/src/arch/riscv32.rs
+++ b/sys/kern/src/arch/riscv32.rs
@@ -686,7 +686,6 @@ pub fn start_first_task(tick_divisor: u32, task: &task::Task) -> ! {
         // Configure MPP to switch us to User mode on exit from Machine
         // mode (when we call "mret" below).
         register::mstatus::set_mpp(MPP::User);
-        register::mstatus::set_mpie();
     }
 
     // Write the initial task program counter.


### PR DESCRIPTION
M-mode interrupts are always enabled in lower priv modes. `mpie` was just unnecessarily setting the `mie` bit for u-mode.