### PR TITLE
sys/kern: Make set_time_result common across 32 and 64-bit arch

### DIFF
--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -573,22 +573,12 @@ pub trait ArchState: Default {
         let now_u64 = u64::from(now);
         let dl_u64 = dl.map(u64::from).unwrap_or(0);
 
-        #[cfg(target_pointer_width = "32")]
-        {
-            self.ret0(now_u64 as usize);
-            self.ret1((now_u64 >> 32) as usize);
-            self.ret2(dl.is_some() as usize);
-            self.ret3(dl_u64 as usize);
-            self.ret4((dl_u64 >> 32) as usize);
-            self.ret5(not.0 as usize);
-        }
-        #[cfg(target_pointer_width = "64")]
-        {
-            self.ret0(now_u64 as usize);
-            self.ret1(dl.is_some() as usize);
-            self.ret2(dl_u64 as usize);
-            self.ret3(not.0 as usize);
-        }
+        self.ret0(now_u64 as u32 as usize);
+        self.ret1((now_u64 >> 32) as usize);
+        self.ret2(dl.is_some() as usize);
+        self.ret3(dl_u64 as u32 as usize);
+        self.ret4((dl_u64 >> 32) as usize);
+        self.ret5(not.0 as usize);
     }
 
     /// Sets the results of REFRESH_TASK_ID


### PR DESCRIPTION
Earlier `set_time_result` was passing args differently from kernel to user depending upon whether it is 32-bit or 64-bit arch. However, this is unnecessary as the userlib arch-agnostic code expects to layout the 64-bit timestamp into 2 32-bit structure members anyways by the userlib arch dependent code. Thus, instead of following two different patterns for 32-bit to 64-bit:

+---------------------+-----------------+---------------+
|Boundary             | 32-bit          | 64-bit        |
+---------------------+-----------------+---------------+
|Kern AA -> Kern AD   | 1x 64 -> 2x 32  |1x 64 -> 1x 64 |
+---------------------+-----------------+---------------+
|Kern AD -> User AD   | 2x 32 -> 2x 32  |1x 64 -> 1x 64 |
+---------------------+-----------------+---------------+
|User AD -> User AA   | 2x 32 -> 2x 32  |1x 64 -> 2x 32 |
+---------------------+-----------------+---------------+
|User AA -> Task      | 2x 32 -> 1x 64  |2x 32 -> 1x 64 |
+---------------------+-----------------+---------------+

(AA = arch agnostic, AD = arch dependent)

we end up following similar pattern for both as below with the current change:

+---------------------+-----------------+---------------+
|Boundary             | 32-bit          | 64-bit        |
+---------------------+-----------------+---------------+
|Kern AA -> Kern AD   | 1x 64 -> 2x 32  |1x 64 -> 2x 32 |
+---------------------+-----------------+---------------+
|Kern AD -> User AD   | 2x 32 -> 2x 32  |2x 32 -> 2x 32 |
+---------------------+-----------------+---------------+
|User AD -> User AA   | 2x 32 -> 2x 32  |2x 32 -> 2x 32 |
+---------------------+-----------------+---------------+
|User AA -> Task      | 2x 32 -> 1x 64  |2x 32 -> 1x 64 |
+---------------------+-----------------+---------------+