### PR TITLE
PLIC Cleanup

### DIFF
--- a/drv/ext-int-ctrl-api/src/lib.rs
+++ b/drv/ext-int-ctrl-api/src/lib.rs
@@ -9,7 +9,7 @@ use userlib::*;
 
 #[derive(Copy, Clone, Debug, FromPrimitive, IdolError)]
 pub enum ExtIntCtrlError {
-    IRQUnassigned,
+    IRQUnassigned = 1,
 }
 
 include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/drv/riscv-plic-server/src/main.rs
+++ b/drv/riscv-plic-server/src/main.rs
@@ -171,10 +171,11 @@ fn main() -> ! {
     let plic = unsafe { &mut *PLIC_REGISTER_BLOCK };
     plic.set_threshold(0, Priority::highest());
 
-    // Zero all interrupt sources ...
+    // Set priority for interrupts that are used to a nonzero value. Used
+    // interrupts are left masked as the task that owns them should decide when
+    // they should first be enabled.
     for i in 1..1024 {
         let priority = if irq_assigned(i) {
-            plic.unmask(0, i as usize);
             Priority::from_bits(1)
         } else {
             Priority::never()

--- a/sys/kern/src/arch/riscv32.rs
+++ b/sys/kern/src/arch/riscv32.rs
@@ -678,11 +678,6 @@ pub fn start_first_task(tick_divisor: u32, task: &task::Task) -> ! {
         // Machine timer interrupt enable
         register::mie::set_mtimer();
 
-        //
-        // Machine external interrupt enable
-        //
-        register::mie::set_mext();
-
         // Configure MPP to switch us to User mode on exit from Machine
         // mode (when we call "mret" below).
         register::mstatus::set_mpp(MPP::User);


### PR DESCRIPTION
Fixes a bug where Idol functions that the server returned an error for were not returning errors to the client. Also fixes PLIC interrupt behavior to be in line with what is expected of interrupts delivered by the kernel at startup, and changed `mie::mext` to be disabled at startup.