### PR TITLE
Orphaned linker sections now cause errors

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -1183,20 +1183,26 @@ fn build(
         .map(|r| format!(" --remap-path-prefix={}={}", r.0.display(), r.1))
         .collect();
 
-    cmd.env(
-        "RUSTFLAGS",
-        &format!(
-            "
-             -C link-arg=-z -C link-arg=common-page-size=0x20 \
-             -C link-arg=-z -C link-arg=max-page-size=0x20 \
-             -C llvm-args=--enable-machine-outliner=never \
-             -C overflow-checks=y \
-             -C metadata={} \
-             {}
-             ",
-            cfg.link_script_hash, remap_path_prefix,
-        ),
+    let mut rustflags: String = format!(
+        "
+         -C link-arg=-z -C link-arg=common-page-size=0x20 \
+         -C link-arg=-z -C link-arg=max-page-size=0x20 \
+         -C llvm-args=--enable-machine-outliner=never \
+         -C overflow-checks=y \
+         -C metadata={} \
+         {}
+         ",
+        cfg.link_script_hash, remap_path_prefix,
     );
+
+    match cfg.arch_target {
+        ArchTarget::RISCV => {
+            rustflags.push_str(" -C link-arg=--orphan-handling=error")
+        }
+        ArchTarget::ARM => {}
+    }
+
+    cmd.env("RUSTFLAGS", &rustflags);
     cmd.arg("--");
     cmd.arg("-C")
         .arg("link-arg=-Tlink.x")

--- a/lds/rv32/kernel-link.x
+++ b/lds/rv32/kernel-link.x
@@ -122,6 +122,30 @@ SECTIONS
 
   .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
   .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
+
+  .debug_loc (INFO) : { *(.debug_loc) }
+  .debug_abbrev (INFO) : { *(.debug_abbrev) }
+  .debug_info (INFO) : { *(.debug_info) }
+  .debug_aranges (INFO) : { *(.debug_aranges) }
+  .debug_ranges (INFO) : { *(.debug_ranges) }
+  .debug_str (INFO) : { *(.debug_str) }
+  .debug_pubnames (INFO) : { *(.debug_pubnames) }
+  .debug_pubtypes (INFO) : { *(.debug_pubtypes) }
+  .debug_line (INFO) : { *(.debug_line) }
+  .debug_frame(INFO) : { *(.debug_frame) }
+
+  .riscv.attributes (INFO) : { *(.riscv.attributes) }
+
+  .llvmbc (INFO) : { *(.llvmbc) }
+  .llvmcmd (INFO) : { *(.llvmcmd) }
+
+  .note.GNU-stack (INFO) : { *(.note.GNU-stack) }
+
+  .symtab (INFO) : { *(.symtab) }
+  .shstrtab (INFO) : { *(.shstrtab) }
+  .strtab (INFO) : { *(.strtab) }
+
+  .comment (INFO) : { *(.comment) }
 }
 
 /* Do not exceed this mark in the error messages above                                    | */

--- a/lds/rv32/task-link.x
+++ b/lds/rv32/task-link.x
@@ -83,6 +83,30 @@ SECTIONS
   .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
   .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 
+  .debug_loc (INFO) : { *(.debug_loc) }
+  .debug_abbrev (INFO) : { *(.debug_abbrev) }
+  .debug_info (INFO) : { *(.debug_info) }
+  .debug_aranges (INFO) : { *(.debug_aranges) }
+  .debug_ranges (INFO) : { *(.debug_ranges) }
+  .debug_str (INFO) : { *(.debug_str) }
+  .debug_pubnames (INFO) : { *(.debug_pubnames) }
+  .debug_pubtypes (INFO) : { *(.debug_pubtypes) }
+  .debug_line (INFO) : { *(.debug_line) }
+  .debug_frame(INFO) : { *(.debug_frame) }
+
+  .riscv.attributes (INFO) : { *(.riscv.attributes) }
+
+  .llvmbc (INFO) : { *(.llvmbc) }
+  .llvmcmd (INFO) : { *(.llvmcmd) }
+
+  .note.GNU-stack (INFO) : { *(.note.GNU-stack) }
+
+  .symtab (INFO) : { *(.symtab) }
+  .shstrtab (INFO) : { *(.shstrtab) }
+  .strtab (INFO) : { *(.strtab) }
+
+  .comment (INFO) : { *(.comment) }
+
   /* ## .task_slot_table */
   /* Table of TaskSlot instances and their names. Used to resolve task
      dependencies during packaging. */

--- a/lds/rv32/task-rlink.x
+++ b/lds/rv32/task-rlink.x
@@ -66,6 +66,30 @@ SECTIONS
   .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
   .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 
+  .debug_loc (INFO) : { *(.debug_loc) }
+  .debug_abbrev (INFO) : { *(.debug_abbrev) }
+  .debug_info (INFO) : { *(.debug_info) }
+  .debug_aranges (INFO) : { *(.debug_aranges) }
+  .debug_ranges (INFO) : { *(.debug_ranges) }
+  .debug_str (INFO) : { *(.debug_str) }
+  .debug_pubnames (INFO) : { *(.debug_pubnames) }
+  .debug_pubtypes (INFO) : { *(.debug_pubtypes) }
+  .debug_line (INFO) : { *(.debug_line) }
+  .debug_frame(INFO) : { *(.debug_frame) }
+
+  .riscv.attributes (INFO) : { *(.riscv.attributes) }
+
+  .llvmbc (INFO) : { *(.llvmbc) }
+  .llvmcmd (INFO) : { *(.llvmcmd) }
+
+  .note.GNU-stack (INFO) : { *(.note.GNU-stack) }
+
+  .symtab (INFO) : { *(.symtab) }
+  .shstrtab (INFO) : { *(.shstrtab) }
+  .strtab (INFO) : { *(.strtab) }
+
+  .comment (INFO) : { *(.comment) }
+
   /* ## .task_slot_table */
   /* Table of TaskSlot instances and their names. Used to resolve task
      dependencies during packaging. */

--- a/lds/rv32/task-tlink.x
+++ b/lds/rv32/task-tlink.x
@@ -76,6 +76,30 @@ SECTIONS
   .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
   .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
 
+  .debug_loc (INFO) : { *(.debug_loc) }
+  .debug_abbrev (INFO) : { *(.debug_abbrev) }
+  .debug_info (INFO) : { *(.debug_info) }
+  .debug_aranges (INFO) : { *(.debug_aranges) }
+  .debug_ranges (INFO) : { *(.debug_ranges) }
+  .debug_str (INFO) : { *(.debug_str) }
+  .debug_pubnames (INFO) : { *(.debug_pubnames) }
+  .debug_pubtypes (INFO) : { *(.debug_pubtypes) }
+  .debug_line (INFO) : { *(.debug_line) }
+  .debug_frame(INFO) : { *(.debug_frame) }
+
+  .riscv.attributes (INFO) : { *(.riscv.attributes) }
+
+  .llvmbc (INFO) : { *(.llvmbc) }
+  .llvmcmd (INFO) : { *(.llvmcmd) }
+
+  .note.GNU-stack (INFO) : { *(.note.GNU-stack) }
+
+  .symtab (INFO) : { *(.symtab) }
+  .shstrtab (INFO) : { *(.shstrtab) }
+  .strtab (INFO) : { *(.strtab) }
+
+  .comment (INFO) : { *(.comment) }
+
   /* ## .task_slot_table */
   /* Table of TaskSlot instances and their names. Used to resolve task
      dependencies during packaging. */


### PR DESCRIPTION
We have faced multiple bugs in the past due to orphaned sections in the linker. By adding the `--orphan-handling=error` flag to the linker invocation, we can prevent such bugs from happening in the future.

The linker scripts have all been updated, so all existing tasks should still build. That being said, I am unsure if I have correctly assigned all of the sections, so those changes should be properly reviewed.