### PR TITLE
Changed `riscv` dependencies to point to our fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "kern",
  "panic-halt",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.1",
  "riscv-rt",
 ]
 
@@ -543,7 +543,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "kern",
  "panic-halt",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.1",
  "riscv-rt",
 ]
 
@@ -687,7 +687,7 @@ dependencies = [
  "build-util",
  "drv-ext-int-ctrl-api",
  "ringbuf",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "userlib",
@@ -1081,7 +1081,7 @@ dependencies = [
  "phash",
  "phash-gen",
  "ringbuf",
- "riscv 0.8.0 (git+https://github.com/rivosinc/riscv?branch=dev/fawaz/plic)",
+ "riscv 0.8.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "ron 0.7.0",
@@ -1892,7 +1892,7 @@ dependencies = [
  "cortex-m-semihosting 0.3.7",
  "phash",
  "phash-gen",
- "riscv 0.8.0 (git+https://github.com/rivosinc/riscv?branch=rivos/dev)",
+ "riscv 0.8.1",
  "riscv-pseudo-atomics",
  "riscv-rt",
  "riscv-semihosting",
@@ -2639,19 +2639,8 @@ dependencies = [
 
 [[package]]
 name = "riscv"
-version = "0.8.0"
-source = "git+https://github.com/rivosinc/riscv?branch=dev/fawaz/plic#bb206d785d090f2f75209bc16304a02da54584cd"
-dependencies = [
- "bare-metal 1.0.0",
- "bit_field",
- "embedded-hal",
- "volatile-register",
-]
-
-[[package]]
-name = "riscv"
-version = "0.8.0"
-source = "git+https://github.com/rivosinc/riscv?branch=rivos/dev#e439c5fa821ba736aca593c9c1bc17ad9493a153"
+version = "0.8.1"
+source = "git+https://github.com/rivosinc/riscv?branch=rivos/dev#b13cb4c7cc7c450d2f6ea03c21520d80bb760cdf"
 dependencies = [
  "bare-metal 1.0.0",
  "bit_field",
@@ -2665,7 +2654,7 @@ version = "0.1.0"
 source = "git+https://github.com/rivosinc/riscv-psuedo-atomics?branch=rivos/main#4a652974468bafbafe8b95603423e88904c98458"
 dependencies = [
  "cfg-if 1.0.0",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.0",
 ]
 
 [[package]]
@@ -2675,7 +2664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527ddfacbbfeed89256163c2655b0392c4aa76dd95c0189dc05044bf2c47c3f8"
 dependencies = [
  "r0 1.0.0",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.0",
  "riscv-rt-macros",
  "riscv-target",
 ]
@@ -2697,7 +2686,7 @@ version = "0.0.1"
 source = "git+https://github.com/rivosinc/riscv-semihosting?branch=dev/fawaz/privilege-features#4e96e44f4518111678d6797b79d39c13d26d71d0"
 dependencies = [
  "cfg-if 1.0.0",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.0",
 ]
 
 [[package]]
@@ -3194,7 +3183,7 @@ name = "task-idle"
 version = "0.1.0"
 dependencies = [
  "cortex-m",
- "riscv 0.7.0",
+ "riscv 0.8.1",
  "userlib",
 ]
 
@@ -3214,7 +3203,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "ringbuf",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "serde",
@@ -3562,7 +3551,7 @@ dependencies = [
  "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "num-traits",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.1",
  "riscv-semihosting",
  "test-api",
  "userlib",
@@ -3607,7 +3596,7 @@ dependencies = [
  "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "num-traits",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "test-api",
@@ -3628,7 +3617,7 @@ dependencies = [
  "hubris-num-tasks",
  "hypocalls",
  "num-traits",
- "riscv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "riscv 0.8.1",
  "riscv-semihosting",
  "task-config",
  "test-api",

--- a/app/demo-hifive-inventor/Cargo.toml
+++ b/app/demo-hifive-inventor/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 [dependencies]
 cfg-if = "0.1.10"
 panic-halt = "0.2.0"
-riscv = "0.8.0"
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-rt = "0.9.0"
 
 [dependencies.kern]

--- a/app/demo-hifive1-revb/Cargo.toml
+++ b/app/demo-hifive1-revb/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 [dependencies]
 cfg-if = "0.1.10"
 panic-halt = "0.2.0"
-riscv = "0.8.0"
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-rt = "0.9.0"
 
 

--- a/drv/fe310-rtc/Cargo.toml
+++ b/drv/fe310-rtc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
 ringbuf = {path = "../../lib/ringbuf" }
 drv-ext-int-ctrl-api = {path = "../ext-int-ctrl-api"}
-riscv = { version = "0.8" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", optional = true, features = ["default", "user-mode"] }
 riscv-pseudo-atomics = { git = "https://github.com/rivosinc/riscv-psuedo-atomics", branch = "rivos/main", features = ["default", "user-mode"] }
 

--- a/drv/riscv-plic-server/Cargo.toml
+++ b/drv/riscv-plic-server/Cargo.toml
@@ -8,7 +8,7 @@ userlib = {path = "../../sys/userlib" }
 phash = { path = "../../lib/phash" }
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
-riscv = { git = "https://github.com/rivosinc/riscv", branch = "dev/fawaz/plic" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", optional = true, features = ["default", "user-mode"] }
 riscv-pseudo-atomics = { git = "https://github.com/rivosinc/riscv-psuedo-atomics", branch = "rivos/main", features = ["default", "user-mode"] }
 drv-ext-int-ctrl-api = { path = "../ext-int-ctrl-api" }

--- a/task/idle/Cargo.toml
+++ b/task/idle/Cargo.toml
@@ -16,7 +16,7 @@ userlib = {path = "../../sys/userlib"}
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-riscv = { version = "0.7" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/jefe/Cargo.toml
+++ b/task/jefe/Cargo.toml
@@ -36,7 +36,7 @@ cortex-m-semihosting = { version = "0.5.0", optional = true }
 armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-riscv = { version = "0.8" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", optional = true, features = ["default", "user-mode"] }
 riscv-pseudo-atomics = { git = "https://github.com/rivosinc/riscv-psuedo-atomics", branch = "rivos/main", features = ["default", "user-mode"] }
 

--- a/test/test-assist/Cargo.toml
+++ b/test/test-assist/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m = {version = "0.7", features = ["inline-asm"]}
 cortex-m-semihosting = { version = "0.5.0", optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-riscv = { version = "0.8" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", features = ["default", "user-mode"] }
 
 [features]

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -20,7 +20,7 @@ armv6m-atomic-hack = {path = "../../lib/armv6m-atomic-hack"}
 cortex-m-semihosting = { version = "0.5.0", optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-riscv = { version = "0.8" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", features = ["default", "user-mode"] }
 riscv-pseudo-atomics = { git = "https://github.com/rivosinc/riscv-psuedo-atomics", branch = "rivos/main", features = ["default", "user-mode"] }
 

--- a/test/test-suite/Cargo.toml
+++ b/test/test-suite/Cargo.toml
@@ -26,7 +26,7 @@ build-i2c = {path = "../../build/i2c", optional = true}
 cortex-m = {version = "0.7", features = ["inline-asm"]}
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-riscv = { version = "0.8" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", features = ["default", "user-mode"] }
 
 [features]


### PR DESCRIPTION
At the moment, we're pulling the `riscv` crate from three different sources. While they were not too different from each other, keeping them as a single source should slightly speed up builds and makes it easier to debug any bugs that come up.

Having these point to our GitHub is a temporary measure until I can get the time to try and upstream our changes.