### PR TITLE
chips: modify qemu scripts to use `final.ihex`.

### DIFF
--- a/chips/fe310-g002/qemu.sh
+++ b/chips/fe310-g002/qemu.sh
@@ -1,1 +1,1 @@
-qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.bin -semihosting -semihosting-config enable=on,userspace=on
+qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.ihex -semihosting -semihosting-config enable=on,userspace=on

--- a/chips/fe310-g003/qemu.sh
+++ b/chips/fe310-g003/qemu.sh
@@ -1,1 +1,1 @@
-qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.bin -semihosting -semihosting-config enable=on,userspace=on
+qemu-system-riscv32 -M sifive_u,msel=1 -nographic -serial mon:stdio -device loader,addr=0x20010000,cpu-num=0,file=final.ihex -semihosting -semihosting-config enable=on,userspace=on


### PR DESCRIPTION
Qemu limits the size of `.bin` images to the size of ram, and gives a vague load error that is hard to debug.  This restriction does not apply to `ihex`.

While this is not currently causing problems, the error is hard to debug and I do not want to run into the problem in the future.  This was discovered when working on the opentitan port.  See [here](https://github.com/rivosinc/hubris/pull/12#discussion_r974709550)  for some background.