### PR TITLE
Add extratext regions to task peripheral list

### DIFF
--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -296,11 +296,15 @@ impl Config {
             match self.peripherals.get(name) {
                 Some(peripheral) => task_peripherals
                     .insert(name.to_string(), peripheral.clone()),
-                None => panic!(
-                    "Task {} uses non-existing peripheral {}",
-                    task_name.to_string(),
-                    name
-                ),
+                None => match self.extratext.get(name) {
+                    Some(peripheral) => task_peripherals
+                        .insert(name.to_string(), peripheral.clone()),
+                    None => panic!(
+                        "Task {} uses unknown peripheral {}",
+                        task_name.to_string(),
+                        name
+                    ),
+                },
             };
         }
 


### PR DESCRIPTION
Apps can specify a section, `extratext`, that provides some extra space for them to read/write in. These regions are used by adding them to the `uses` field, but they come from the app.toml rather than the chip.toml. There is nothing in our tree that uses this, but there is in upstream, and without this change `xtask` will panic as it doesn't see the name in the list of peripherals from the `chip.toml`.