### PR TITLE
Fix mtime behavior

### DIFF
--- a/sys/kern/src/arch/riscv32.rs
+++ b/sys/kern/src/arch/riscv32.rs
@@ -435,11 +435,11 @@ fn timer_handler() {
                 set_current_task(next);
             }
 
-            // Reset mtime back to 0.  In theory we could save an instruction on
-            // RV32 here and only write the low-order bits, assuming that it has
-            // been less than 12 seconds or so since our last interrupt(!), but
-            // let's avoid any possibility of a nasty surprise.
-            core::ptr::write_volatile(crate::startup::MTIME as *mut u64, 0);
+            //
+            // Increase mtimecmp for the next interrupt
+            // This will also clear the pending timer interrupt.
+            //
+            reset_timer();
         })
     }
     crate::profiling::event_timer_isr_exit();
@@ -621,45 +621,23 @@ unsafe fn handle_fault(task: *mut task::Task, fault: FaultInfo) {
 // We currently only support single HART systems.  From reading elsewhere,
 // additional harts have their own mtimecmp offset at 0x8 intervals from hart0.
 //
-// As per FE310-G002 Manual, section 9.1, the address of mtimecmp on
-// our supported board is 0x0200_4000, which also matches qemu.
-//
-// On both RV32 and RV64 systems the mtime and mtimecmp memory-mapped registers
-// are 64-bits wide.
-//
-
 // Configure the timer.
 //
 // RISC-V Privileged Architecture Manual
 // 3.2.1 Machine Timer Registers (mtime and mtimecmp)
 //
-// To keep things simple, especially on RV32 systems where we cannot atomically
-// write to the mtime/mtimecmp memory-mapped registers as they are 64 bits
-// wide, we only utilise the first 32-bits of each register, setting the
-// high-order bits to 0 on startup, and restarting the low-order bits of mtime
-// back to 0 on each interrupt.
-//
-#[no_mangle]
-unsafe fn set_timer(tick_divisor: u32) {
-    // Set high-order bits of mtime to zero.  We only call this function prior
-    // to enabling interrupts so it should be safe.
+unsafe fn reset_timer() {
+    //
+    // Increase mtimecmp for the next interrupt
+    // This will also clear the pending timer interrupt.
+    //
     unsafe {
-        asm!("
-            li {0}, {mtimecmp}  # load mtimecmp address
-            li {1}, -1          # start with all low-order bits set
-            sw {1}, 0({0})      # set low-order bits -1
-            sw zero, 4({0})     # set high-order bits to 0
-            sw {2}, 0({0})      # set low-order bits to tick_divisor
-
-            li {0}, {mtime}     # load mtime address
-            sw zero, 4({0})     # set high-order bits to 0
-            sw zero, 0({0})     # set low-order bits back to 0
-            ",
-            out(reg) _,
-            out(reg) _,
-            in(reg) tick_divisor,
-            mtime = const crate::startup::MTIME,
-            mtimecmp = const crate::startup::MTIMECMP,
+        let mut mtimecmp =
+            core::ptr::read_volatile(crate::startup::MTIMECMP as *mut u64);
+        mtimecmp = mtimecmp + CLOCK_FREQ_KHZ as u64;
+        core::ptr::write_volatile(
+            crate::startup::MTIMECMP as *mut u64,
+            mtimecmp,
         );
     }
 }
@@ -672,8 +650,12 @@ pub fn start_first_task(tick_divisor: u32, task: &task::Task) -> ! {
         //
         CLOCK_FREQ_KHZ = tick_divisor;
 
-        // Reset mtime back to 0, set mtimecmp to chosen timer
-        set_timer(tick_divisor - 1);
+        // make MTIMECMP start with MTIME
+        let mtime = core::ptr::read_volatile(crate::startup::MTIME as *mut u64);
+        core::ptr::write_volatile(crate::startup::MTIMECMP as *mut u64, mtime);
+
+        // increment mtimecmp for appropriate timer interrupts
+        reset_timer();
 
         // Machine timer interrupt enable
         register::mie::set_mtimer();


### PR DESCRIPTION
No longer zero `mtime`, just increment `mtimecmp`.