### PR TITLE
Remove `HUBRIS_TASK_ID_MAP`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,6 @@ dependencies = [
  "drv-ext-int-ctrl-api",
  "idol",
  "idol-runtime",
- "indexmap",
  "num-traits",
  "phash",
  "phash-gen",
@@ -1246,10 +1245,7 @@ dependencies = [
  "riscv 0.8.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
- "ron 0.7.0",
- "serde",
  "task-config",
- "toml",
  "userlib",
  "zerocopy",
 ]

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -220,18 +220,6 @@ impl Config {
             }
         }
 
-        // WARNING: Because this map provides task ID numbers directly, its
-        // contents can be used to send messages to tasks without creating a
-        // task_slot, so it's possible to deadlock. Use this with caution.
-        let mut task_id_map: BTreeMap<String, u32> = BTreeMap::new();
-        for (i, (name, _)) in self.tasks.iter().enumerate() {
-            task_id_map.insert(name.to_string(), i.try_into().unwrap());
-        }
-        env.insert(
-            "HUBRIS_TASK_ID_MAP".to_string(),
-            ron::ser::to_string(&task_id_map).unwrap(),
-        );
-
         // secure_separation indicates that we have TrustZone enabled.
         // When TrustZone is enabled, the bootloader is secure and hubris is
         // not secure.

--- a/drv/riscv-plic-server/Cargo.toml
+++ b/drv/riscv-plic-server/Cargo.toml
@@ -21,10 +21,6 @@ idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 task-config = { path = "../../lib/task-config" }
 abi = {path = "../../sys/abi" }
 phash-gen = {path = "../../build/phash-gen"}
-ron = "0.7"
-toml = "0.5.6"
-serde = { version = "1.0.114", features = ["derive"] }
-indexmap = { version = "1.4.0" }
 
 [features]
 semihosting-riscv = [ "riscv-semihosting", "userlib/log-semihosting" ]

--- a/drv/riscv-plic-server/build.rs
+++ b/drv/riscv-plic-server/build.rs
@@ -76,9 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    println!("{}", &env::var("HUBRIS_TASK_ID_MAP")?);
-    let task_id_map: std::collections::BTreeMap<String, u16> =
-        ron::de::from_str(&env::var("HUBRIS_TASK_ID_MAP")?)?;
+    let task_id_map: build_util::TaskIds = build_util::task_ids();
 
     let mut irq_task_map: Vec<(InterruptNum, (TaskId, u32))> = Vec::new();
     let mut per_task_irqs: HashMap<InterruptOwner, Vec<InterruptNum>> =
@@ -87,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for (i, irq) in TASK_CONFIG.ints.into_iter().enumerate() {
         let task: String = TASK_CONFIG.tasks[i].to_string();
         let task_id: TaskId = match task_id_map.get(&task) {
-            Some(id_num) => TaskId(*id_num),
+            Some(id_num) => TaskId(id_num.try_into().unwrap()),
             None => panic!("Error: no matching task ID for task {}", task),
         };
 


### PR DESCRIPTION
Upstream added a way for tasks' `build.rs` to get access to a map of task names to their IDs in `build_util`, so these patches switch the PLIC server to use that instead of the environment variable that we added and remove said environment variable.