### PR TITLE
Generate IRQ notification constants

### DIFF
--- a/app/demo-hifive-inventor/app.toml
+++ b/app/demo-hifive-inventor/app.toml
@@ -30,6 +30,7 @@ interrupts = { "plic.irq" = 0x1 }
 ints = [52]
 tasks = ['"rtc"']
 notification = [1]
+source = ['"rtc"']
 pbits = 3
 
 [tasks.rtc]

--- a/build/util/src/lib.rs
+++ b/build/util/src/lib.rs
@@ -121,6 +121,10 @@ pub fn task_peripherals_str() -> String {
     return consts;
 }
 
+pub fn task_irq_consts() -> String {
+    env::var("HUBRIS_TASK_IRQS").expect("missing HUBRIS_TASK_IRQS")
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Peripheral {

--- a/build/xtask/src/config.rs
+++ b/build/xtask/src/config.rs
@@ -332,6 +332,24 @@ impl Config {
             ron::ser::to_string(&task_peripherals).unwrap(),
         );
 
+        // Expose interrupt notification bits as constants
+        let interrupts: IndexMap<String, u32> = task_toml.interrupts.clone();
+        let mut notif_consts: String = String::new();
+
+        for (name, notif) in interrupts {
+            notif_consts.push_str("const ");
+            for part in name.split('.') {
+                notif_consts.push_str(
+                    format!("{}_", part.to_ascii_uppercase()).as_str(),
+                );
+            }
+            notif_consts.push_str(
+                format!("NOTIFICATION: u32 = 0x{:X};\n", notif).as_str(),
+            );
+        }
+
+        out.env.insert("HUBRIS_TASK_IRQS".to_string(), notif_consts);
+
         Ok(out)
     }
 

--- a/drv/fe310-rtc/build.rs
+++ b/drv/fe310-rtc/build.rs
@@ -13,6 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         File::create(out.join("rtc_config.rs")).unwrap()
     };
 
+    writeln!(file, "{}", build_util::task_irq_consts())?;
     writeln!(file, "{}", build_util::task_peripherals_str())?;
 
     return Ok(());

--- a/drv/riscv-plic-server/build.rs
+++ b/drv/riscv-plic-server/build.rs
@@ -29,6 +29,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         File::create(out.join("plic_config.rs")).unwrap()
     };
 
+    writeln!(file, "{}", build_util::task_irq_consts())?;
+
     writeln!(
         file,
         "use phash::{{PerfectHashMap, MutablePerfectHashMap}};"

--- a/drv/riscv-plic-server/src/main.rs
+++ b/drv/riscv-plic-server/src/main.rs
@@ -15,8 +15,6 @@ use drv_ext_int_ctrl_api::ExtIntCtrlError;
 use idol_runtime::RequestError;
 use idol_runtime::RequestError::Runtime;
 
-const PLIC_IRQ: u32 = 0x0000_0001;
-
 fn get_irq_owner(irq: u32) -> Result<(TaskId, u32), ()> {
     return match unsafe { HUBRIS_IRQ_TASK_LOOKUP.get(InterruptNum(irq)) } {
         Some(task) => return Ok(*task),
@@ -122,7 +120,7 @@ impl idl::InOrderExtIntCtrlImpl for ServerImpl {
 impl idol_runtime::NotificationHandler for ServerImpl {
     // The PLIC is only interested in interrupt notifications from the kernel
     fn current_notification_mask(&self) -> u32 {
-        return PLIC_IRQ;
+        return PLIC_IRQ_NOTIFICATION;
     }
 
     // An interrupt has come in.
@@ -162,7 +160,7 @@ impl idol_runtime::NotificationHandler for ServerImpl {
             }
         }
 
-        sys_irq_control(PLIC_IRQ, true);
+        sys_irq_control(PLIC_IRQ_NOTIFICATION, true);
     }
 }
 
@@ -188,7 +186,7 @@ fn main() -> ! {
 
     plic.set_threshold(0, Priority::never());
     let mut server: ServerImpl = ServerImpl {};
-    sys_irq_control(PLIC_IRQ, true);
+    sys_irq_control(PLIC_IRQ_NOTIFICATION, true);
     loop {
         idol_runtime::dispatch_n(&mut incoming, &mut server);
     }


### PR DESCRIPTION
This adds a per-task environment variable, `HUBRIS_TASK_IRQS`, that
contains the code to create constants for interrupts the task recieves
through the kernel. For example, if a task has the interrupt
`"plic.irq" = 0x1`, the environemnt variable will contain:
`const PLIC_IRQ_NOTIFICATION: u32 = 0x1;`.

This also adds a function to `build_util`, `task_irq_consts()`, that
reads this environment variable and returns its contents as a `String`.

The PLIC server is also switched to use these consts.

IRQ notificaiton constants are now also generated for IRQs coming from
the external interrupt controller. This requires a new field in the
config, `source`, which will be used to generate the const name, like
so: `{SOURCE}_NOTIFICATION`. The FE310 RTC task now uses these.