### PR TITLE
One-shot tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,6 +3733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "task-one-shot"
+version = "0.1.0"
+dependencies = [
+ "cortex-m-semihosting 0.5.0",
+ "riscv-semihosting",
+ "userlib",
+]
+
+[[package]]
 name = "task-ping"
 version = "0.1.0"
 dependencies = [

--- a/app/demo-hifive-inventor/app.toml
+++ b/app/demo-hifive-inventor/app.toml
@@ -55,6 +55,14 @@ stacksize = 512
 start = true
 task-slots = [{peer = "pong"}]
 
+[tasks.one_shot]
+name = "task-one-shot"
+priority = 1
+max-sizes = { flash = 8192, ram = 1024 }
+stacksize = 512
+start = true
+features = ["semihosting"]
+
 [tasks.idle]
 name = "task-idle"
 priority = 5

--- a/doc/kipc.adoc
+++ b/doc/kipc.adoc
@@ -113,6 +113,8 @@ pub enum SchedState {
     /// This task is blocked waiting for messages, either from any source
     /// (`None`) or from a particular sender only.
     InRecv(Option<TaskId>),
+    /// This task ran and cleanly exited. It is ignored for scheduling purposes.
+    Exited,
 }
 ----
 
@@ -215,6 +217,12 @@ you apply `fault_task` to an already-faulted task, the task will be marked as
 double-faulted and the previous fault will be replaced with the new injected
 fault.
 
+=== `exit_current_task` (6)
+
+Allows a task to exit once it is done running. This puts the task into `Exited`
+state. The task will not be chosen for scheduling henceforth until it is restarted
+by the supervisor task.
+
 == Receiving from the kernel
 
 The kernel never sends messages to tasks. It's simply not equipped to do so.
@@ -235,4 +243,5 @@ forever (or at least, until the supervisor reinits it), you can receive from the
 kernel with _no_ notification mask bits set.
 
 NOTE: We haven't needed that second one in practice, so we might make it an
-error someday. The first one, on the other hand, is useful.
+error someday. The first one, on the other hand, is useful. In order to handle the
+second case, `exit_current_task` can be used instead.

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -605,6 +605,7 @@ pub enum Kipcnum {
     FaultTask = 3,
     ReadImageId = 4,
     Reset = 5,
+    ExitCurrentTask = 6,
 }
 
 impl core::convert::TryFrom<u16> for Kipcnum {
@@ -617,6 +618,7 @@ impl core::convert::TryFrom<u16> for Kipcnum {
             3 => Ok(Self::FaultTask),
             4 => Ok(Self::ReadImageId),
             5 => Ok(Self::Reset),
+            6 => Ok(Self::ExitCurrentTask),
             _ => Err(()),
         }
     }

--- a/sys/abi/src/lib.rs
+++ b/sys/abi/src/lib.rs
@@ -409,6 +409,8 @@ pub enum SchedState {
     /// This task is blocked waiting for messages, either from any source
     /// (`None`) or from a particular sender only.
     InRecv(Option<TaskId>),
+    /// This task ran and cleanly exited. It is ignored for scheduling purposes.
+    Exited,
 }
 
 impl From<SchedState> for TaskState {

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -25,6 +25,7 @@ pub fn handle_kernel_message(
             read_task_status(tasks, caller, args.message?, args.response?)
         }
         Ok(Kipcnum::RestartTask) => restart_task(tasks, caller, args.message?),
+        Ok(Kipcnum::ExitCurrentTask) => exit_current_task(tasks, caller, args.message?),
         Ok(Kipcnum::FaultTask) => fault_task(tasks, caller, args.message?),
         Ok(Kipcnum::ReadImageId) => {
             read_image_id(tasks, caller, args.response?)
@@ -95,6 +96,14 @@ fn read_task_status(
         .save_mut()
         .set_send_response_and_length(0, response_len);
     Ok(NextTask::Same)
+}
+
+fn exit_current_task(
+    tasks: &mut [Task],
+    caller: usize,
+    _message: USlice<u8>,
+) -> Result<NextTask, UserError> {
+    Ok(crate::task::exit_task(tasks, caller))
 }
 
 fn restart_task(

--- a/sys/kern/src/kipc.rs
+++ b/sys/kern/src/kipc.rs
@@ -25,7 +25,9 @@ pub fn handle_kernel_message(
             read_task_status(tasks, caller, args.message?, args.response?)
         }
         Ok(Kipcnum::RestartTask) => restart_task(tasks, caller, args.message?),
-        Ok(Kipcnum::ExitCurrentTask) => exit_current_task(tasks, caller, args.message?),
+        Ok(Kipcnum::ExitCurrentTask) => {
+            exit_current_task(tasks, caller, args.message?)
+        }
         Ok(Kipcnum::FaultTask) => fault_task(tasks, caller, args.message?),
         Ok(Kipcnum::ReadImageId) => {
             read_image_id(tasks, caller, args.response?)

--- a/sys/kern/src/startup.rs
+++ b/sys/kern/src/startup.rs
@@ -27,7 +27,7 @@ use core::sync::atomic::Ordering;
 /// `false` late in `start_kernel`.
 static TASK_TABLE_IN_USE: AtomicBool = AtomicBool::new(true);
 
-pub const HUBRIS_FAULT_NOTIFICATION: u32 = 1;
+pub const HUBRIS_TASK_STATE_CHANGE_NOTIFICATION: u32 = 1;
 
 /// The main kernel entry point.
 ///

--- a/sys/kern/src/startup.rs
+++ b/sys/kern/src/startup.rs
@@ -27,8 +27,6 @@ use core::sync::atomic::Ordering;
 /// `false` late in `start_kernel`.
 static TASK_TABLE_IN_USE: AtomicBool = AtomicBool::new(true);
 
-pub const HUBRIS_TASK_STATE_CHANGE_NOTIFICATION: u32 = 1;
-
 /// The main kernel entry point.
 ///
 /// We currently expect an application to provide its own `main`-equivalent

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -16,7 +16,7 @@ use zerocopy::FromBytes;
 use crate::arch;
 use crate::err::UserError;
 use crate::profiling;
-use crate::startup::HUBRIS_FAULT_NOTIFICATION;
+use crate::startup::HUBRIS_TASK_STATE_CHANGE_NOTIFICATION;
 use crate::time::Timestamp;
 use crate::umem::USlice;
 
@@ -811,7 +811,7 @@ pub fn priority_scan(
 
 fn notify_supervisor(tasks: &mut [Task]) -> NextTask {
     let supervisor_awoken =
-        tasks[0].post(NotificationSet(HUBRIS_FAULT_NOTIFICATION));
+        tasks[0].post(NotificationSet(HUBRIS_TASK_STATE_CHANGE_NOTIFICATION));
     if supervisor_awoken {
         NextTask::Specific(0)
     } else {

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -16,9 +16,10 @@ use zerocopy::FromBytes;
 use crate::arch;
 use crate::err::UserError;
 use crate::profiling;
-use crate::startup::HUBRIS_TASK_STATE_CHANGE_NOTIFICATION;
 use crate::time::Timestamp;
 use crate::umem::USlice;
+
+const HUBRIS_TASK_STATE_CHANGE_NOTIFICATION: u32 = 1;
 
 /// Internal representation of a task.
 ///

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -870,7 +870,7 @@ pub fn force_fault(
 ///
 /// Returns a `NextTask` because the calling task cannot be scheduled anymore.
 pub fn exit_task(tasks: &mut [Task], index: usize) -> NextTask {
-    tasks[index].set_healthy_state(SchedState::Stopped);
+    tasks[index].set_healthy_state(SchedState::Exited);
     notify_supervisor(tasks)
 }
 

--- a/sys/kern/src/task.rs
+++ b/sys/kern/src/task.rs
@@ -868,10 +868,7 @@ pub fn force_fault(
 /// The task will not be scheduled again until requested to restart it again.
 ///
 /// Returns a `NextTask` because the calling task cannot be scheduled anymore.
-pub fn exit_task(
-    tasks: &mut[Task],
-    index: usize,
-) -> NextTask {
+pub fn exit_task(tasks: &mut [Task], index: usize) -> NextTask {
     tasks[index].set_healthy_state(SchedState::Stopped);
     notify_supervisor(tasks)
 }

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -24,6 +24,15 @@ pub fn read_task_status(task: usize) -> abi::TaskState {
     ssmarshal::deserialize(&response[..len]).unwrap_lite().0
 }
 
+pub fn exit_current_task() {
+    sys_send(TaskId::KERNEL,
+             Kipcnum::ExitCurrentTask as u16,
+             &[],
+             &mut [],
+             &[],
+    );
+}
+
 pub fn restart_task(task: usize, start: bool) {
     // Coerce `task` to a known size (Rust doesn't assume that usize == u32)
     let msg = (task as u32, start);

--- a/sys/userlib/src/kipc.rs
+++ b/sys/userlib/src/kipc.rs
@@ -25,11 +25,12 @@ pub fn read_task_status(task: usize) -> abi::TaskState {
 }
 
 pub fn exit_current_task() {
-    sys_send(TaskId::KERNEL,
-             Kipcnum::ExitCurrentTask as u16,
-             &[],
-             &mut [],
-             &[],
+    sys_send(
+        TaskId::KERNEL,
+        Kipcnum::ExitCurrentTask as u16,
+        &[],
+        &mut [],
+        &[],
     );
 }
 

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -237,8 +237,8 @@ impl idol_runtime::NotificationHandler for ServerImpl<'_> {
                         }
                     }
 
-                    abi::TaskState::Healthy(abi::SchedState::Stopped) |
-                        abi::TaskState::Healthy(abi::SchedState::Exited) => {
+                    abi::TaskState::Healthy(abi::SchedState::Stopped)
+                    | abi::TaskState::Healthy(abi::SchedState::Exited) => {
                         if self.disposition[i] == Disposition::Start {
                             kipc::restart_task(i, true);
                         }

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -237,7 +237,8 @@ impl idol_runtime::NotificationHandler for ServerImpl<'_> {
                         }
                     }
 
-                    abi::TaskState::Healthy(abi::SchedState::Stopped) => {
+                    abi::TaskState::Healthy(abi::SchedState::Stopped) |
+                        abi::TaskState::Healthy(abi::SchedState::Exited) => {
                         if self.disposition[i] == Disposition::Start {
                             kipc::restart_task(i, true);
                         }

--- a/task/jefe/src/main.rs
+++ b/task/jefe/src/main.rs
@@ -113,8 +113,8 @@ pub enum Disposition {
 // notification, but can otherwise be arbitrary.
 const TIMER_INTERVAL: u64 = 100;
 const TIMER_MASK: u32 = 1 << 1;
-// We'll have notification 0 wired up to receive information about task faults.
-const FAULT_MASK: u32 = 1 << 0;
+// We'll have notification 0 wired up to receive information about task state changes.
+const TASK_STATE_CHANGE_MASK: u32 = 1 << 0;
 
 #[export_name = "main"]
 fn main() -> ! {
@@ -206,7 +206,7 @@ impl idl::InOrderJefeImpl for ServerImpl<'_> {
 
 impl idol_runtime::NotificationHandler for ServerImpl<'_> {
     fn current_notification_mask(&self) -> u32 {
-        FAULT_MASK | TIMER_MASK
+        TASK_STATE_CHANGE_MASK | TIMER_MASK
     }
 
     fn handle_notification(&mut self, bits: u32) {
@@ -221,7 +221,7 @@ impl idol_runtime::NotificationHandler for ServerImpl<'_> {
 
         // If our disposition has changed or if we have been notified of
         // a faulting task, we need to iterate over all of our tasks.
-        if changed || (bits & FAULT_MASK) != 0 {
+        if changed || (bits & TASK_STATE_CHANGE_MASK) != 0 {
             for i in 0..NUM_TASKS {
                 match kipc::read_task_status(i) {
                     abi::TaskState::Faulted { fault, .. } => {

--- a/task/one-shot/Cargo.toml
+++ b/task/one-shot/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "task-one-shot"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+userlib = {path = "../../sys/userlib", features = ["panic-messages"]}
+
+[target.'cfg(target_arch = "arm")'.dependencies]
+cortex-m-semihosting = { version = "0.5.0", optional = true }
+
+[target.'cfg(target_arch = "riscv32")'.dependencies]
+riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", features = ["default", "user-mode"], optional = true }
+
+[features]
+semihosting = ["userlib/log-semihosting", "riscv-semihosting", "cortex-m-semihosting"]
+
+# This section is here to discourage RLS/rust-analyzer from doing test builds,
+# since test builds don't work for cross compilation.
+[[bin]]
+name = "task-one-shot"
+test = false
+bench = false

--- a/task/one-shot/README.mkdn
+++ b/task/one-shot/README.mkdn
@@ -1,0 +1,3 @@
+# Task One shot
+
+This is a sample task to demonstrate one-shot behavior i.e. tasks that do the work and perform exit task operation to move to stopped state.

--- a/task/one-shot/README.mkdn
+++ b/task/one-shot/README.mkdn
@@ -1,3 +1,4 @@
 # Task One shot
 
-This is a sample task to demonstrate one-shot behavior i.e. tasks that do the work and perform exit task operation to move to stopped state.
+This is a sample task to demonstrate one-shot behavior i.e. tasks that do the work and perform
+exit task operation to move to stopped state.

--- a/task/one-shot/src/main.rs
+++ b/task/one-shot/src/main.rs
@@ -13,6 +13,5 @@ fn main() -> ! {
     sys_log!("Exiting now!");
     kipc::exit_current_task();
 
-    // Adding this just to make rustc happy
-    loop {}
+    unreachable!();
 }

--- a/task/one-shot/src/main.rs
+++ b/task/one-shot/src/main.rs
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+use userlib::*;
+
+#[export_name = "main"]
+fn main() -> ! {
+    sys_log!("Hello world from one-shot task!");
+    sys_log!("Exiting now!");
+    kipc::exit_current_task();
+
+    // Adding this just to make rustc happy
+    loop {}
+}


### PR DESCRIPTION
Enable support for tasks to move to stopped state. In the future, we will need changes to enable some task (supervisor/controller) to decide that we are done with all work and ask kernel to stop by doing a wfi or jumping to some other entity. This is the first step towards that change.