### PR TITLE
Added CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# For now, just have `hubris-humility-maintainers handle everything.
+*   @rivosinc/hubris-humility-maintainers
+


### PR DESCRIPTION
With this, all PRs will automatically add @rivosinc/hubris-humility-maintainers to the reviewers, and approval from someone in that group will be required before a merge.