### PR TITLE
Bring in nix dev shell and CI checks

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -3,7 +3,20 @@ on:
   pull_request:
   push:
 jobs:
+  skip_duplicate_jobs:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   linux-checks:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.4.0
@@ -13,6 +26,8 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
     - run: nix flake check
   darwin-checks:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     runs-on: macOS-latest 
     steps:
     - uses: actions/checkout@v2.4.0

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -14,21 +14,13 @@ jobs:
           concurrent_skipping: 'same_content'
           skip_after_successful_duplicate: 'true'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-  linux-checks:
+  flake-checks:
     needs: skip_duplicate_jobs
     if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v15
-      with:
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - run: nix flake check
-  darwin-checks:
-    needs: skip_duplicate_jobs
-    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
-    runs-on: macOS-latest 
+    strategy:
+      matrix: 
+        os: [ ubuntu-latest, macOS-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v15

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,23 @@
+name: "Nix flake checks"
+on:
+  pull_request:
+  push:
+jobs:
+  linux-checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix flake check
+  darwin-checks:
+    runs-on: macOS-latest 
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix flake check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "hkdf",
- "hubpack 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hubpack",
  "lpc55-pac",
  "salty",
  "serde",
@@ -1767,7 +1767,7 @@ version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?rev=7e5d68e0094bcf40f55e7640b2a8a56e4f743409#7e5d68e0094bcf40f55e7640b2a8a56e4f743409"
 dependencies = [
  "bitflags",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
+ "hubpack",
  "serde",
  "serde-big-array",
  "serde_repr",
@@ -1989,7 +1989,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "fletcher",
- "hubpack 0.1.0 (git+https://github.com/cbiffle/hubpack)",
+ "hubpack",
  "serde",
  "serde_repr",
  "unwrap-lite",
@@ -1998,56 +1998,16 @@ dependencies = [
 [[package]]
 name = "hubpack"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e0e5e2a94d97b34fa215ea1311937ab0880f86ee575ca4acd2ff66fa22b88c"
-dependencies = [
- "hubpack_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
-]
-
-[[package]]
-name = "hubpack"
-version = "0.1.0"
 source = "git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
 dependencies = [
- "hubpack_derive 0.1.0 (git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25)",
+ "hubpack_derive",
  "serde",
-]
-
-[[package]]
-name = "hubpack"
-version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack#d98084b85cc45fe589a49dd95403d7b41533375c"
-dependencies = [
- "hubpack_derive 0.1.0 (git+https://github.com/cbiffle/hubpack)",
- "serde",
-]
-
-[[package]]
-name = "hubpack_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd74819b334bf50982a40ec2a44cdf4e197ebbc74c02624897ecb66dbf828c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
 name = "hubpack_derive"
 version = "0.1.0"
 source = "git+https://github.com/cbiffle/hubpack?rev=df08cc3a6e1f97381cd0472ae348e310f0119e25#df08cc3a6e1f97381cd0472ae348e310f0119e25"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "hubpack_derive"
-version = "0.1.0"
-source = "git+https://github.com/cbiffle/hubpack#d98084b85cc45fe589a49dd95403d7b41533375c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32g0 0.15.1",
+ "stm32g0",
 ]
 
 [[package]]
@@ -640,7 +640,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32g0 0.14.0",
+ "stm32g0",
 ]
 
 [[package]]
@@ -1394,7 +1394,7 @@ dependencies = [
  "cortex-m-semihosting 0.5.0",
  "drv-stm32xx-sys-api",
  "num-traits",
- "stm32g0 0.14.0",
+ "stm32g0",
  "userlib",
  "zerocopy",
 ]
@@ -1524,7 +1524,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "num-traits",
- "stm32g0 0.14.0",
+ "stm32g0",
  "stm32h7",
  "userlib",
  "zerocopy",
@@ -1540,7 +1540,7 @@ dependencies = [
  "drv-stm32xx-sys-api",
  "num-traits",
  "ringbuf",
- "stm32g0 0.15.1",
+ "stm32g0",
  "stm32h7",
  "userlib",
  "zerocopy",
@@ -1561,7 +1561,7 @@ dependencies = [
  "fixedmap",
  "num-traits",
  "ringbuf",
- "stm32g0 0.15.1",
+ "stm32g0",
  "stm32h7",
  "userlib",
 ]
@@ -1577,7 +1577,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
- "stm32g0 0.14.0",
+ "stm32g0",
  "stm32h7",
  "task-jefe-api",
  "userlib",
@@ -3395,17 +3395,6 @@ dependencies = [
 
 [[package]]
 name = "stm32g0"
-version = "0.14.0"
-source = "git+https://github.com/oxidecomputer/stm32-rs-nightlies?branch=stm32g0b1-initial-support#19280bfc90cce3020482abc1d0c57d7d2a3bf162"
-dependencies = [
- "bare-metal 1.0.0",
- "cortex-m",
- "cortex-m-rt",
- "vcell",
-]
-
-[[package]]
-name = "stm32g0"
 version = "0.15.1"
 source = "git+https://github.com/oxidecomputer/stm32-rs-nightlies?branch=stm32g0b1-update#9bb993b07a5906ac4503d702e7ff507f229d1b44"
 dependencies = [
@@ -4173,7 +4162,7 @@ dependencies = [
  "panic-halt",
  "panic-itm",
  "panic-semihosting",
- "stm32g0 0.14.0",
+ "stm32g0",
 ]
 
 [[package]]

--- a/app/demo-stm32g0-nucleo/Cargo.toml
+++ b/app/demo-stm32g0-nucleo/Cargo.toml
@@ -19,7 +19,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "1"
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false, features = ["rt"] }
+stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false, features = ["rt"] }
 
 [dependencies.kern]
 path = "../../sys/kern"

--- a/drv/stm32g0-usart/Cargo.toml
+++ b/drv/stm32g0-usart/Cargo.toml
@@ -8,7 +8,7 @@ userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api", default-features = false}
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
+stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false }
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-semihosting = { version = "0.5.0" }
 

--- a/drv/stm32xx-gpio-common/Cargo.toml
+++ b/drv/stm32xx-gpio-common/Cargo.toml
@@ -15,7 +15,7 @@ zerocopy = "0.6.1"
 [dependencies.stm32g0]
 optional = true
 git = "https://github.com/oxidecomputer/stm32-rs-nightlies"
-branch = "stm32g0b1-initial-support"
+branch = "stm32g0b1-update"
 default-features = false
 
 [features]

--- a/drv/stm32xx-sys/Cargo.toml
+++ b/drv/stm32xx-sys/Cargo.toml
@@ -8,7 +8,7 @@ bitflags = "1.2.1"
 userlib = {path = "../../sys/userlib"}
 zerocopy = "0.6.1"
 num-traits = { version = "0.2.12", default-features = false }
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false, optional = true }
+stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false, optional = true }
 stm32h7 = {version = "0.14", default-features = false, optional = true}
 idol-runtime = {git = "https://github.com/oxidecomputer/idolatry.git"}
 drv-stm32xx-sys-api = {path = "../stm32xx-sys-api"}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "humilityflake": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665537097,
+        "narHash": "sha256-+poG6I/cAeht6Xhv/wgo3LcFWVbRMcmqW/7oqxv7RTI=",
+        "owner": "rivosinc",
+        "repo": "humility",
+        "rev": "9aec1b5e2209f82711e6a0429c36186628c9c5f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rivosinc",
+        "repo": "humility",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666096911,
+        "narHash": "sha256-c/pv4MiFiPFfMPgiWN5qc9ADYcTkPlMCE4SYZBedB0Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5c77b29073f0d679aee8056da3ced1cfb3d3aecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "humilityflake": "humilityflake",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1666062111,
+        "narHash": "sha256-OI0xx5Wx3Yph6Hg+aD3tn2csDLNWJqmXXWee85mlQuU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8643439d1db65a33ca6813d0aa8956b2be4bd91d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,151 @@
+{
+  description = "package set for rivos hubris builds";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.rust-overlay.inputs.flake-utils.follows = "flake-utils";
+
+  inputs.humilityflake.url = "github:rivosinc/humility";
+  inputs.humilityflake.inputs.rust-overlay.follows = "rust-overlay";
+  inputs.humilityflake.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.humilityflake.inputs.flake-utils.follows = "flake-utils";
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+    humilityflake,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      overlays = [(import rust-overlay)];
+
+      pkgs = import nixpkgs {
+        inherit system overlays;
+      };
+
+      # This is a little funky since the default riscv binutils use `none` rather than `unknown`
+      riscv64-unknown-none-elf-stdenv = pkgs.stdenv.override {
+        targetPlatform = {
+          config = "riscv64-unknown-elf";
+          system = "riscv64-none";
+          parsed = {
+            kernel = {
+              execFormat = {
+                name = "unknown";
+              };
+              name = "none";
+            };
+          };
+          isiOS = false;
+          isAarch32 = false;
+          isWindows = false;
+          isMips64n64 = false;
+          isMusl = false;
+          isPower = false;
+          isVc4 = false;
+        };
+      };
+      riscv32-unknown-none-elf-stdenv = pkgs.stdenv.override {
+        targetPlatform = {
+          config = "riscv32-unknown-elf";
+          system = "riscv32-none";
+          parsed = {
+            kernel = {
+              execFormat = {
+                name = "unknown";
+              };
+              name = "none";
+            };
+          };
+          isiOS = false;
+          isAarch32 = false;
+          isWindows = false;
+          isMips64n64 = false;
+          isMusl = false;
+          isPower = false;
+          isVc4 = false;
+        };
+      };
+
+      rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+      #since hubris looks for 64bit named binaries
+      binutils32 = pkgs.binutils-unwrapped.override {
+        stdenv = riscv32-unknown-none-elf-stdenv;
+      };
+      binutils64 = pkgs.binutils-unwrapped.override {
+        stdenv = riscv64-unknown-none-elf-stdenv;
+      };
+
+      hubris = (
+        {
+          app,
+          toml,
+          doCheck ? false,
+        }:
+          pkgs.callPackage ./nix/hubris.nix {
+            inherit binutils64 app toml doCheck;
+            cargo = rust;
+            rustc = rust;
+            src = pkgs.lib.cleanSource ./.;
+            version = "beta";
+          }
+      );
+
+      hubris-test-suite-runner = (
+        {
+          hubris,
+          app,
+        }:
+          pkgs.callPackage ./nix/qemu-test-suite.nix {
+            inherit hubris app;
+            humility = humilityflake.packages.${system}.humility;
+          }
+      );
+
+      target = "demo-hifive-inventor";
+    in {
+      packages = flake-utils.lib.flattenTree {
+        demo-hifive1-revb = hubris {
+          app = "demo-hifive1-revb";
+          toml = "app/demo-hifive1-revb/app.toml";
+        };
+        demo-hifive-inventor = hubris {
+          app = "demo-hifive-inventor";
+          toml = "app/demo-hifive-inventor/app.toml";
+        };
+        tests-hifive-inventor = hubris {
+          app = "tests-hifive-inventor";
+          toml = "test/tests-hifive-inventor/app.toml";
+        };
+      };
+
+      devShells.default = pkgs.mkShell {
+        shellHook = ''
+          export HUMILITY_ARCHIVE=$(pwd)/target/${target}/dist/default/build-${target}.zip
+          export CARGO_HOME=$HOME/.cargo
+        '';
+
+        nativeBuildInputs = with pkgs; [
+          rust
+          qemu
+          binutils32
+          binutils64
+          humilityflake.packages.${system}.humility
+        ];
+      };
+
+      checks = {
+        # build checks
+        demo-hifive1-revb = self.packages.${system}.demo-hifive-inventor.override {doCheck = true;};
+        demo-hifive-inventor = self.packages.${system}.demo-hifive-inventor.override {doCheck = true;};
+        tests-hifive-inventor = self.packages.${system}.tests-hifive-inventor.override {doCheck = true;};
+      };
+
+      formatter = nixpkgs.legacyPackages.${system}.alejandra;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -86,9 +86,10 @@
           app,
           toml,
           doCheck ? false,
+          sixtyfour ? false,
         }:
           pkgs.callPackage ./nix/hubris.nix {
-            inherit binutils64 app toml doCheck;
+            inherit binutils64 app toml doCheck sixtyfour;
             cargo = rust;
             rustc = rust;
             src = pkgs.lib.cleanSource ./.;
@@ -100,9 +101,10 @@
         {
           hubris,
           app,
+          sixtyfour ? false,
         }:
           pkgs.callPackage ./nix/qemu-test-suite.nix {
-            inherit hubris app;
+            inherit hubris app sixtyfour;
             humility = humilityflake.packages.${system}.humility;
           }
       );

--- a/lib/dice/Cargo.toml
+++ b/lib/dice/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 hkdf = { version = "0.12", default-features = false }
-hubpack = "0.1"
+hubpack = { git = "https://github.com/cbiffle/hubpack", rev = "df08cc3a6e1f97381cd0472ae348e310f0119e25" }
 lpc55-pac = "0.4"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde-big-array = "0.4"

--- a/lib/host-sp-messages/Cargo.toml
+++ b/lib/host-sp-messages/Cargo.toml
@@ -9,6 +9,6 @@ fletcher = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_repr = "0.1"
 
-hubpack = { git = "https://github.com/cbiffle/hubpack" }
+hubpack = { git = "https://github.com/cbiffle/hubpack", rev = "df08cc3a6e1f97381cd0472ae348e310f0119e25" }
 
 unwrap-lite = { path = "../unwrap-lite" }

--- a/nix/hubris.nix
+++ b/nix/hubris.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  tree,
+  binutils64,
+  qemu,
+  cargo,
+  rustc,
+  toml ? null,
+  app ? null,
+  rev ? "dirty",
+  version,
+  src,
+  doCheck ? false,
+}:
+# host and build platform are linux
+# target platform should be riscv32
+stdenv.mkDerivation rec {
+  inherit src version doCheck;
+  name = "hubris";
+
+  CARGO_HOME = src;
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = src + /Cargo.lock;
+    outputHashes = {
+      "gateway-messages-0.1.0" = "sha256-7vQTj/j5iQTqqQjgXSM7G2VnWLhXGR/AuCpo2LU1/uw";
+      "hif-0.3.1" = "sha256-o3r1akaSARfqIzuP86SJc6/s0b2PIkaZENjYO3DPAUo";
+      "hubpack-0.1.0" = "sha256-Q5wwLAWbwCVociZBeTy9SeCF0MmKmcG0C3LQAtdw/Mc";
+      "idol-0.2.0" = "sha256-kkaVPgr7kp+xif4Me6DvNwN6QLKJYAkT6mLD4pMH1Aw";
+      "lpc55_sign-0.1.0" = "sha256-To4+Dn/BcvpBwQRNaI+wn68G4hqpCrmO/2CLqCcdWTE";
+      "ordered-toml-0.1.0" = "sha256-hJjyF9bXt5CfemV5/ogPViaNHZsINrQkZG45Ta65Qm4";
+      "pmbus-0.1.0" = "sha256-rKEbuWUp88PJK+gP6dmaIeeBNXzjclNpwE5kibViYQQ";
+      "riscv-0.8.1" = "sha256-icLG4b/jpn4thGoeXHHBAEqF6FLV8u/8N0KLOgeQcO0";
+      "riscv-pseudo-atomics-0.1.0" = "sha256-QuChdKbw1TTy8W+mr3gF8yDfwWcUxmAzT3j5A5gamdk";
+      "riscv-semihosting-0.0.1" = "sha256-JzQyv2/4F1FBclFZUsIOJ1TREaBIKQp/TOZhBSHyQGY";
+      "salty-0.2.0" = "sha256-8RnvQ+Ch4RijmOhWNQZh7PmFlZGUfyzbeRvSKWqsbJU";
+      "spd-0.1.0" = "sha256-X6XUx+huQp77XF5EZDYYqRqaHsdDSbDMK8qcuSGob3E";
+      "stm32g0-0.15.1" = "sha256-mWY3CU0bUdlBKZKAoyjGVSdT3KVLgPHb4Jjb/JvPXEA";
+      "tlvc-0.1.0" = "sha256-uHPPyc3Ns5L1/EFNCzH8eBEoqLlJoqguZxwNCNxfM6Q";
+      "vsc7448-pac-0.1.0" = "sha256-otNLdfGIzuyu03wEb7tzhZVVMdS0of2sU/AKSNSsoho";
+    };
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    tree
+    cargo
+    rustc
+  ];
+
+  depsBuildTarget = [
+    binutils64
+  ];
+
+  patchPhase = ''
+    substituteInPlace build/xtask/src/dist.rs --replace 'get_git_status()?' '("${rev}", false)'
+  '';
+
+  buildPhase = ''
+    ${cargo}/bin/cargo --offline --frozen xtask dist ${toml}
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp target/${app}/ $out/ -a
+  '';
+
+  dontFixup = true;
+
+  checkPhase = ''
+    pushd ${src}
+    ${cargo}/bin/cargo --offline --frozen fmt --check --all
+    popd
+  '';
+
+  meta = with lib; {
+    description = "kernel";
+    platforms = platforms.all;
+  };
+}

--- a/nix/hubris.nix
+++ b/nix/hubris.nix
@@ -9,73 +9,79 @@
   rustc,
   toml ? null,
   app ? null,
+  sixtyfour ? false,
   rev ? "dirty",
   version,
   src,
   doCheck ? false,
-}:
-# host and build platform are linux
-# target platform should be riscv32
-stdenv.mkDerivation rec {
-  inherit src version doCheck;
-  name = "hubris";
+}: let
+  xtask =
+    if sixtyfour
+    then "xtask64"
+    else "xtask";
+in
+  # host and build platform are linux
+  # target platform should be riscv32
+  stdenv.mkDerivation rec {
+    inherit src version doCheck;
+    name = "hubris";
 
-  CARGO_HOME = src;
-  cargoDeps = rustPlatform.importCargoLock {
-    lockFile = src + /Cargo.lock;
-    outputHashes = {
-      "gateway-messages-0.1.0" = "sha256-7vQTj/j5iQTqqQjgXSM7G2VnWLhXGR/AuCpo2LU1/uw";
-      "hif-0.3.1" = "sha256-o3r1akaSARfqIzuP86SJc6/s0b2PIkaZENjYO3DPAUo";
-      "hubpack-0.1.0" = "sha256-Q5wwLAWbwCVociZBeTy9SeCF0MmKmcG0C3LQAtdw/Mc";
-      "idol-0.2.0" = "sha256-kkaVPgr7kp+xif4Me6DvNwN6QLKJYAkT6mLD4pMH1Aw";
-      "lpc55_sign-0.1.0" = "sha256-To4+Dn/BcvpBwQRNaI+wn68G4hqpCrmO/2CLqCcdWTE";
-      "ordered-toml-0.1.0" = "sha256-hJjyF9bXt5CfemV5/ogPViaNHZsINrQkZG45Ta65Qm4";
-      "pmbus-0.1.0" = "sha256-rKEbuWUp88PJK+gP6dmaIeeBNXzjclNpwE5kibViYQQ";
-      "riscv-0.8.1" = "sha256-icLG4b/jpn4thGoeXHHBAEqF6FLV8u/8N0KLOgeQcO0";
-      "riscv-pseudo-atomics-0.1.0" = "sha256-QuChdKbw1TTy8W+mr3gF8yDfwWcUxmAzT3j5A5gamdk";
-      "riscv-semihosting-0.0.1" = "sha256-JzQyv2/4F1FBclFZUsIOJ1TREaBIKQp/TOZhBSHyQGY";
-      "salty-0.2.0" = "sha256-8RnvQ+Ch4RijmOhWNQZh7PmFlZGUfyzbeRvSKWqsbJU";
-      "spd-0.1.0" = "sha256-X6XUx+huQp77XF5EZDYYqRqaHsdDSbDMK8qcuSGob3E";
-      "stm32g0-0.15.1" = "sha256-mWY3CU0bUdlBKZKAoyjGVSdT3KVLgPHb4Jjb/JvPXEA";
-      "tlvc-0.1.0" = "sha256-uHPPyc3Ns5L1/EFNCzH8eBEoqLlJoqguZxwNCNxfM6Q";
-      "vsc7448-pac-0.1.0" = "sha256-otNLdfGIzuyu03wEb7tzhZVVMdS0of2sU/AKSNSsoho";
+    CARGO_HOME = src;
+    cargoDeps = rustPlatform.importCargoLock {
+      lockFile = src + /Cargo.lock;
+      outputHashes = {
+        "gateway-messages-0.1.0" = "sha256-7vQTj/j5iQTqqQjgXSM7G2VnWLhXGR/AuCpo2LU1/uw";
+        "hif-0.3.1" = "sha256-o3r1akaSARfqIzuP86SJc6/s0b2PIkaZENjYO3DPAUo";
+        "hubpack-0.1.0" = "sha256-Q5wwLAWbwCVociZBeTy9SeCF0MmKmcG0C3LQAtdw/Mc";
+        "idol-0.2.0" = "sha256-kkaVPgr7kp+xif4Me6DvNwN6QLKJYAkT6mLD4pMH1Aw";
+        "lpc55_sign-0.1.0" = "sha256-To4+Dn/BcvpBwQRNaI+wn68G4hqpCrmO/2CLqCcdWTE";
+        "ordered-toml-0.1.0" = "sha256-hJjyF9bXt5CfemV5/ogPViaNHZsINrQkZG45Ta65Qm4";
+        "pmbus-0.1.0" = "sha256-rKEbuWUp88PJK+gP6dmaIeeBNXzjclNpwE5kibViYQQ";
+        "riscv-0.8.1" = "sha256-icLG4b/jpn4thGoeXHHBAEqF6FLV8u/8N0KLOgeQcO0";
+        "riscv-pseudo-atomics-0.1.0" = "sha256-QuChdKbw1TTy8W+mr3gF8yDfwWcUxmAzT3j5A5gamdk";
+        "riscv-semihosting-0.0.1" = "sha256-JzQyv2/4F1FBclFZUsIOJ1TREaBIKQp/TOZhBSHyQGY";
+        "salty-0.2.0" = "sha256-8RnvQ+Ch4RijmOhWNQZh7PmFlZGUfyzbeRvSKWqsbJU";
+        "spd-0.1.0" = "sha256-X6XUx+huQp77XF5EZDYYqRqaHsdDSbDMK8qcuSGob3E";
+        "stm32g0-0.15.1" = "sha256-mWY3CU0bUdlBKZKAoyjGVSdT3KVLgPHb4Jjb/JvPXEA";
+        "tlvc-0.1.0" = "sha256-uHPPyc3Ns5L1/EFNCzH8eBEoqLlJoqguZxwNCNxfM6Q";
+        "vsc7448-pac-0.1.0" = "sha256-otNLdfGIzuyu03wEb7tzhZVVMdS0of2sU/AKSNSsoho";
+      };
     };
-  };
 
-  nativeBuildInputs = [
-    rustPlatform.cargoSetupHook
-    tree
-    cargo
-    rustc
-  ];
+    nativeBuildInputs = [
+      rustPlatform.cargoSetupHook
+      tree
+      cargo
+      rustc
+    ];
 
-  depsBuildTarget = [
-    binutils64
-  ];
+    depsBuildTarget = [
+      binutils64
+    ];
 
-  patchPhase = ''
-    substituteInPlace build/xtask/src/dist.rs --replace 'get_git_status()?' '("${rev}", false)'
-  '';
+    patchPhase = ''
+      substituteInPlace build/xtask/src/dist.rs --replace 'get_git_status()?' '("${rev}", false)'
+    '';
 
-  buildPhase = ''
-    ${cargo}/bin/cargo --offline --frozen xtask dist ${toml}
-  '';
+    buildPhase = ''
+      ${cargo}/bin/cargo --offline --frozen ${xtask} dist ${toml}
+    '';
 
-  installPhase = ''
-    mkdir -p $out
-    cp target/${app}/ $out/ -a
-  '';
+    installPhase = ''
+      mkdir -p $out
+      cp target/${app}/ $out/ -a
+    '';
 
-  dontFixup = true;
+    dontFixup = true;
 
-  checkPhase = ''
-    pushd ${src}
-    ${cargo}/bin/cargo --offline --frozen fmt --check --all
-    popd
-  '';
+    checkPhase = ''
+      pushd ${src}
+      ${cargo}/bin/cargo --offline --frozen fmt --check --all
+      popd
+    '';
 
-  meta = with lib; {
-    description = "kernel";
-    platforms = platforms.all;
-  };
-}
+    meta = with lib; {
+      description = "kernel";
+      platforms = platforms.all;
+    };
+  }

--- a/nix/qemu-test-suite.nix
+++ b/nix/qemu-test-suite.nix
@@ -1,0 +1,29 @@
+{
+  runCommand,
+  hubris,
+  humility,
+  qemu,
+  app,
+}:
+runCommand "hubris-qemu-tests" {}
+''
+    echo "running hubris test suite for: " ${app}
+
+    # prepare environment
+    mkdir -p $out
+    export PATH=${qemu}/bin/:$PATH
+    export HUMILITY_ARCHIVE=${hubris}/${app}/dist/default/build-${app}.zip
+
+    ${humility}/bin/humility qemu
+  # &> $out/qemu.log &
+
+    # in reality this happend < 1 sec, but giving some buffer room
+    sleep 10
+    kill $(jobs -p)
+
+    grep "done pass" $out/qemu.log
+
+    cat $out/qemu.log
+
+    echo "test suite passed"
+''

--- a/test/tests-stm32g0/Cargo.toml
+++ b/test/tests-stm32g0/Cargo.toml
@@ -16,7 +16,7 @@ panic-itm = { version = "0.4.1", optional = true }
 panic-halt = { version = "0.2.0", optional = true }
 panic-semihosting = { version = "0.5.3", optional = true }
 cfg-if = "1"
-stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-initial-support", default-features = false }
+stm32g0 = { git = "https://github.com/oxidecomputer/stm32-rs-nightlies", branch = "stm32g0b1-update", default-features = false }
 
 [dependencies.kern]
 path = "../../sys/kern"


### PR DESCRIPTION
The CI changes will check builds on linux and on mac.  We cannot run the test in qemu since the semihosting patches have not landed upstream yet.
 
This also brings in some dependency fixes that we have applied internally.