### PR TITLE
regenerate Cargo.lock to fix `riscv-semihosting` vendoring.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "riscv-semihosting"
 version = "0.0.1"
-source = "git+https://github.com/rivosinc/riscv-semihosting?branch=dev/fawaz/privilege-features#4e96e44f4518111678d6797b79d39c13d26d71d0"
+source = "git+https://github.com/rivosinc/riscv-semihosting?branch=dev/fawaz/privilege-features#ec93c72f47c08d2e852c5e080bbe2e790ec2222d"
 dependencies = [
  "cfg-if 1.0.0",
  "riscv 0.8.0",

--- a/nix/hubris.nix
+++ b/nix/hubris.nix
@@ -39,7 +39,7 @@ in
         "pmbus-0.1.0" = "sha256-rKEbuWUp88PJK+gP6dmaIeeBNXzjclNpwE5kibViYQQ";
         "riscv-0.8.1" = "sha256-icLG4b/jpn4thGoeXHHBAEqF6FLV8u/8N0KLOgeQcO0";
         "riscv-pseudo-atomics-0.1.0" = "sha256-QuChdKbw1TTy8W+mr3gF8yDfwWcUxmAzT3j5A5gamdk";
-        "riscv-semihosting-0.0.1" = "sha256-JzQyv2/4F1FBclFZUsIOJ1TREaBIKQp/TOZhBSHyQGY";
+        "riscv-semihosting-0.0.1" = "sha256-sGa++ywE9kYw9VnPKeYyzaRJsYOzF0mNE7C9c2TdUNQ";
         "salty-0.2.0" = "sha256-8RnvQ+Ch4RijmOhWNQZh7PmFlZGUfyzbeRvSKWqsbJU";
         "spd-0.1.0" = "sha256-X6XUx+huQp77XF5EZDYYqRqaHsdDSbDMK8qcuSGob3E";
         "stm32g0-0.15.1" = "sha256-mWY3CU0bUdlBKZKAoyjGVSdT3KVLgPHb4Jjb/JvPXEA";


### PR DESCRIPTION
The branch we were pointing to got rebased, and the hash changed.

We should probably set up something to prevent this in the future.