### PR TITLE
nix: specify `max-jobs` to get parallel builds

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -28,4 +28,4 @@ jobs:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           max-jobs = auto
-    - run: nix flake check --print-build-logs
+    - run: nix show-config && nix flake check --print-build-logs

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -27,4 +27,5 @@ jobs:
       with:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - run: nix flake check
+          max-jobs = auto
+    - run: nix flake check --print-build-logs


### PR DESCRIPTION
https://nixos.org/manual/nix/unstable/command-ref/conf-file.html#conf-max-jobs

> This option defines the maximum number of jobs that Nix will try to build in parallel. The default is 1. The special value auto causes Nix to use the number of CPUs in your system. 0 is useful when using remote builders to prevent any local builds (except for preferLocalBuild derivation attribute which executes locally regardless). It can be overridden using the --max-jobs (-j) command line switch.