### PR TITLE
xtask: remove dependency on being in a git repo.

### DIFF
--- a/build/xtask/src/dist.rs
+++ b/build/xtask/src/dist.rs
@@ -676,11 +676,17 @@ fn build_archive(cfg: &PackageConfig, image_name: &str) -> Result<()> {
         - debug/ contains OpenOCD and GDB scripts, if available.\n",
     )?;
 
-    let (git_rev, git_dirty) = get_git_status()?;
-    archive.text(
-        "git-rev",
-        format!("{}{}", git_rev, if git_dirty { "-dirty" } else { "" }),
-    )?;
+    match get_git_status() {
+        Ok((git_rev, git_dirty)) => {
+            archive.text(
+                "git-rev",
+                format!("{}{}", git_rev, if git_dirty { "-dirty" } else { "" }),
+            )?;
+        }
+        Err(_) => {
+            println!("{} building outside a git repository, revision will not be avaliable in build", "warning".bold().yellow());
+        }
+    }
     archive.copy(&cfg.app_toml_file, "app.toml")?;
     let chip_dir = cfg.app_src_dir.join(cfg.toml.chip.clone());
     let chip_file = chip_dir.join("chip.toml");

--- a/nix/hubris.nix
+++ b/nix/hubris.nix
@@ -59,10 +59,6 @@ in
       binutils64
     ];
 
-    patchPhase = ''
-      substituteInPlace build/xtask/src/dist.rs --replace 'get_git_status()?' '("${rev}", false)'
-    '';
-
     buildPhase = ''
       ${cargo}/bin/cargo --offline --frozen ${xtask} dist ${toml}
     '';


### PR DESCRIPTION
This makes the inclusion of the git-rev in the build meta data optional. It is only included if the build is occuring in a git repo, otherwise, it will print a warning on the cmd line.

This is motivated by our use of some "meta-build" systems like nix and bazel.   This systems often copy the source, but not the `.git` folder.

`$ humility manifset` will already display the missing hash as: 
```
version => hubris build archive v3
git rev => <unknown>
image id => [25, 84, d8, 65, d6, ea, e6, 76]
...
```