### PR TITLE
nix: add .envrc.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake


### PR DESCRIPTION
This will enable `direnv` to automatically enter the dev environment when you `cd` to the hubris folder.  It will not have any effect if you do not have `direnv` installed.  Even if you have `direnv` installed, it will not automatically run until you approve it for the first time.

See https://direnv.net/ and https://github.com/nix-community/nix-direnv.