### PR TITLE
tests: tests-hifive-inventor: increase test kernel allocation.

### DIFF
--- a/test/tests-hifive-inventor/app.toml
+++ b/test/tests-hifive-inventor/app.toml
@@ -6,7 +6,7 @@ chip = "../../chips/fe310-g003"
 
 [kernel]
 name = "demo-hifive-inventor"
-requires = {flash = 15872, ram = 3232}
+requires = {flash = 15874, ram = 3232}
 features = []
 
 [tasks.runner]


### PR DESCRIPTION
When the size was smaller, qemu was giving obtuse errors.

This is mostly a temporary fix to get the test suite working in qemu again.  I made https://rivosinc.atlassian.net/browse/SW-851 to track the underlying bug.