### PR TITLE
chips: rv64-qemu-virt: add `openocd.gdb`.

### DIFF
--- a/chips/rv64-qemu-virt/openocd.gdb
+++ b/chips/rv64-qemu-virt/openocd.gdb
@@ -1,0 +1,8 @@
+target extended-remote :3333
+
+# print demangled symbols
+set confirm off
+set print asm-demangle on
+
+# set backtrace limit to not have infinite backtrace loops
+set backtrace limit 32


### PR DESCRIPTION
This enables `humility gdb` to work as expected.