### PR TITLE
chips: rv64-qemu-virt: add `qemu.sh`.

### DIFF
--- a/chips/rv64-qemu-virt/qemu.sh
+++ b/chips/rv64-qemu-virt/qemu.sh
@@ -1,0 +1,1 @@
+qemu-system-riscv64 -M virt -nographic -serial mon:stdio  -device loader,addr=0x90000400,cpu-num=0,file=final.bin -semihosting -semihosting-config enable=on,userspace=on -m 8G -bios none


### PR DESCRIPTION
This enables humility to launch the demo apps with `humility qemu`. This is limited to m-mode kernels for now.