### PR TITLE
ci: nix: add flag for printing full logs

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -27,4 +27,4 @@ jobs:
       with:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - run: nix flake check
+    - run: nix flake check --print-build-logs


### PR DESCRIPTION
This got dropped in the `rivos/main-rv64` but is already in `rivos/main`.  It will enable complete log printing when running in CI rather than just the last few lines.