### PR TITLE
move s-mode feature into `app.toml`

### DIFF
--- a/app/demo-rv64-qemu-virt-supervisor/Cargo.toml
+++ b/app/demo-rv64-qemu-virt-supervisor/Cargo.toml
@@ -3,6 +3,9 @@ name = "demo-rv64-qemu-virt-supervisor"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+s-mode = ["riscv-rt/s-mode", "kern/riscv-supervisor-mode"]
+
 [dependencies]
 cfg-if = "1.0.0"
 panic-halt = "0.2.0"
@@ -12,7 +15,7 @@ riscv-rt = { git = "https://github.com/rust-embedded/riscv-rt.git", rev = "be9e6
 [dependencies.kern]
 path = "../../sys/kern"
 default-features = false
-features = ["vectored-interrupts", "riscv-supervisor-mode", "klog-semihosting", "riscv-support-sstc"]
+features = ["vectored-interrupts", "klog-semihosting", "riscv-support-sstc"]
 
 [build-dependencies]
 build-util = {path = "../../build/util"}

--- a/app/demo-rv64-qemu-virt-supervisor/app.toml
+++ b/app/demo-rv64-qemu-virt-supervisor/app.toml
@@ -7,7 +7,7 @@ stacksize = 2048
 [kernel]
 name = "demo-rv64-qemu-virt-supervisor"
 requires = { flash = 20480, ram = 32768 }
-features = []
+features = ["s-mode"]
 
 [tasks.jefe]
 name = "task-jefe"

--- a/test/tests-rv64-qemu-virt-supervisor/app.toml
+++ b/test/tests-rv64-qemu-virt-supervisor/app.toml
@@ -7,7 +7,7 @@ chip = "../../chips/rv64-qemu-virt"
 [kernel]
 name = "demo-rv64-qemu-virt-supervisor"
 requires = {flash = 28672, ram = 65536}
-features = []
+features = ["s-mode"]
 
 [tasks.runner]
 name = "test-runner"


### PR DESCRIPTION
Moving the feature flags out of the `cargo.toml` and into the `app.toml` makes it significantly easier for humility to decode.

I selected @tdewey-rivos supervisor branch as the merge target to represent the merge dependency.