### PR TITLE
bump `riscv` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
 dependencies = [
- "critical-section",
+ "critical-section 0.2.7",
 ]
 
 [[package]]
@@ -482,6 +482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,7 +604,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "kern",
  "panic-halt",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-rt",
 ]
 
@@ -610,7 +616,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "kern",
  "panic-halt",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-rt",
 ]
 
@@ -826,7 +832,7 @@ dependencies = [
  "build-util",
  "drv-ext-int-ctrl-api",
  "ringbuf",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "userlib",
@@ -1242,7 +1248,7 @@ dependencies = [
  "phash",
  "phash-gen",
  "ringbuf",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "task-config",
@@ -2094,7 +2100,7 @@ dependencies = [
  "cortex-m-semihosting 0.3.7",
  "phash",
  "phash-gen",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-rt",
  "riscv-semihosting",
@@ -2883,11 +2889,11 @@ dependencies = [
 
 [[package]]
 name = "riscv"
-version = "0.8.1"
-source = "git+https://github.com/rivosinc/riscv?branch=rivos/dev#b13cb4c7cc7c450d2f6ea03c21520d80bb760cdf"
+version = "0.9.1"
+source = "git+https://github.com/rivosinc/riscv?branch=rivos/dev#d9917932f66cec0fe77dac40a6362afd35ebce2f"
 dependencies = [
- "bare-metal 1.0.0",
  "bit_field",
+ "critical-section 1.1.1",
  "embedded-hal",
  "volatile-register",
 ]
@@ -3534,7 +3540,7 @@ name = "task-idle"
 version = "0.1.0"
 dependencies = [
  "cortex-m",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "userlib",
 ]
 
@@ -3554,7 +3560,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "ringbuf",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "serde",
@@ -3989,7 +3995,7 @@ dependencies = [
  "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "num-traits",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-semihosting",
  "test-api",
  "userlib",
@@ -4034,7 +4040,7 @@ dependencies = [
  "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "num-traits",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "test-api",
@@ -4054,7 +4060,7 @@ dependencies = [
  "drv-i2c-devices",
  "hubris-num-tasks",
  "num-traits",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-semihosting",
  "task-config",
  "test-api",

--- a/app/demo-hifive-inventor/app.toml
+++ b/app/demo-hifive-inventor/app.toml
@@ -6,7 +6,7 @@ stacksize = 896
 
 [kernel]
 name = "demo-hifive-inventor"
-requires = { flash = 16784, ram = 3472 }
+requires = { flash = 17104, ram = 3472 }
 features = []
 
 [tasks.jefe]

--- a/nix/xtask.nix
+++ b/nix/xtask.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       "lpc55_sign-0.1.0" = "sha256-To4+Dn/BcvpBwQRNaI+wn68G4hqpCrmO/2CLqCcdWTE";
       "ordered-toml-0.1.0" = "sha256-hJjyF9bXt5CfemV5/ogPViaNHZsINrQkZG45Ta65Qm4";
       "pmbus-0.1.0" = "sha256-rKEbuWUp88PJK+gP6dmaIeeBNXzjclNpwE5kibViYQQ";
-      "riscv-0.8.1" = "sha256-icLG4b/jpn4thGoeXHHBAEqF6FLV8u/8N0KLOgeQcO0";
+      "riscv-0.9.1" = "sha256-3vgERj0GY2pMRVo6sjXlch/ySeq+gdhCIlS2IWEd/+c";
       "riscv-pseudo-atomics-0.1.0" = "sha256-QuChdKbw1TTy8W+mr3gF8yDfwWcUxmAzT3j5A5gamdk";
       "riscv-semihosting-0.0.1" = "sha256-sGa++ywE9kYw9VnPKeYyzaRJsYOzF0mNE7C9c2TdUNQ";
       "salty-0.2.0" = "sha256-8RnvQ+Ch4RijmOhWNQZh7PmFlZGUfyzbeRvSKWqsbJU";

--- a/sys/kern/src/arch/riscv32.rs
+++ b/sys/kern/src/arch/riscv32.rs
@@ -236,13 +236,13 @@ pub fn apply_memory_protection(task: &task::Task) {
         unsafe {
             // Configure the base address entry
             register::set_cfg_entry(i * 2, null_cfg);
-            register::write_tor_indexed(i * 2, region.base as usize);
+            register::write_tor_indexed(i * 2, region.base as u64);
 
             // Configure the end address entry
             register::set_cfg_entry(i * 2 + 1, pmpcfg);
             register::write_tor_indexed(
                 i * 2 + 1,
-                (region.base + region.size) as usize,
+                region.base as u64 + region.size as u64,
             );
         }
     }

--- a/test/tests-hifive-inventor/app.toml
+++ b/test/tests-hifive-inventor/app.toml
@@ -6,7 +6,7 @@ chip = "../../chips/fe310-g003"
 
 [kernel]
 name = "demo-hifive-inventor"
-requires = {flash = 15904, ram = 3232}
+requires = {flash = 16304, ram = 3232}
 features = []
 
 [tasks.runner]


### PR DESCRIPTION
This will allow memory regions to go all the way to the end of the address space, and will fix https://rivosinc.atlassian.net/browse/SW-884

~~I am leaving as draft to demonstrate the crates functionality, but will wait till the `riscv` changes land in `rivos/dev`, then update all instances of `riscv` crate in hubris.~~