### PR TITLE
bump `riscv` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "kern",
  "panic-halt",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-rt 0.9.0",
 ]
 
@@ -617,7 +617,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "kern",
  "panic-halt",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-rt 0.9.0",
 ]
 
@@ -629,7 +629,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "kern",
  "panic-halt",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-rt 0.9.0",
 ]
 
@@ -857,7 +857,7 @@ dependencies = [
  "build-util",
  "drv-ext-int-ctrl-api",
  "ringbuf",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "userlib",
@@ -1273,7 +1273,7 @@ dependencies = [
  "phash",
  "phash-gen",
  "ringbuf",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "task-config",
@@ -2914,19 +2914,8 @@ dependencies = [
 
 [[package]]
 name = "riscv"
-version = "0.8.1"
-source = "git+https://github.com/rivosinc/riscv?branch=rivos/dev#b13cb4c7cc7c450d2f6ea03c21520d80bb760cdf"
-dependencies = [
- "bare-metal 1.0.0",
- "bit_field",
- "embedded-hal",
- "volatile-register",
-]
-
-[[package]]
-name = "riscv"
 version = "0.9.1"
-source = "git+https://github.com/rivosinc/riscv?rev=247f8ff#247f8ff7f8c25713b280e769d808dd7f96fc43d9"
+source = "git+https://github.com/rivosinc/riscv?branch=rivos/dev#d9917932f66cec0fe77dac40a6362afd35ebce2f"
 dependencies = [
  "bit_field",
  "critical-section 1.1.1",
@@ -2961,7 +2950,7 @@ version = "0.9.1"
 source = "git+https://github.com/rust-embedded/riscv-rt.git?rev=be9e61b79b1ae16a1314134bfb44ae9119554072#be9e61b79b1ae16a1314134bfb44ae9119554072"
 dependencies = [
  "r0 1.0.0",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-rt-macros",
  "riscv-target",
 ]
@@ -3587,7 +3576,7 @@ name = "task-idle"
 version = "0.1.0"
 dependencies = [
  "cortex-m",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "userlib",
 ]
 
@@ -3607,7 +3596,7 @@ dependencies = [
  "idol-runtime",
  "num-traits",
  "ringbuf",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "serde",
@@ -4043,7 +4032,7 @@ dependencies = [
  "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "num-traits",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-semihosting",
  "test-api",
  "userlib",
@@ -4088,7 +4077,7 @@ dependencies = [
  "cortex-m-semihosting 0.5.0",
  "hubris-num-tasks",
  "num-traits",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-pseudo-atomics",
  "riscv-semihosting",
  "test-api",
@@ -4108,7 +4097,7 @@ dependencies = [
  "drv-i2c-devices",
  "hubris-num-tasks",
  "num-traits",
- "riscv 0.8.1",
+ "riscv 0.9.1",
  "riscv-semihosting",
  "task-config",
  "test-api",

--- a/app/demo-hifive-inventor/app.toml
+++ b/app/demo-hifive-inventor/app.toml
@@ -6,7 +6,7 @@ stacksize = 896
 
 [kernel]
 name = "demo-hifive-inventor"
-requires = { flash = 16848, ram = 3232 }
+requires = { flash = 17200, ram = 3232 }
 features = []
 
 [tasks.jefe]

--- a/app/demo-rv64-qemu-virt-supervisor/Cargo.toml
+++ b/app/demo-rv64-qemu-virt-supervisor/Cargo.toml
@@ -9,7 +9,7 @@ s-mode = ["riscv-rt/s-mode", "kern/riscv-supervisor-mode"]
 [dependencies]
 cfg-if = "1.0.0"
 panic-halt = "0.2.0"
-riscv = { git = "https://github.com/rivosinc/riscv", rev = "247f8ff" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-rt = { git = "https://github.com/rust-embedded/riscv-rt.git", rev = "be9e61b79b1ae16a1314134bfb44ae9119554072", features = ["s-mode"] }
 
 [dependencies.kern]

--- a/nix/hubris.nix
+++ b/nix/hubris.nix
@@ -37,8 +37,7 @@ in
         "lpc55_sign-0.1.0" = "sha256-To4+Dn/BcvpBwQRNaI+wn68G4hqpCrmO/2CLqCcdWTE";
         "ordered-toml-0.1.0" = "sha256-hJjyF9bXt5CfemV5/ogPViaNHZsINrQkZG45Ta65Qm4";
         "pmbus-0.1.0" = "sha256-rKEbuWUp88PJK+gP6dmaIeeBNXzjclNpwE5kibViYQQ";
-        "riscv-0.8.1" = "sha256-icLG4b/jpn4thGoeXHHBAEqF6FLV8u/8N0KLOgeQcO0";
-        "riscv-0.9.1" = "sha256-qlacVoP3QLEvFzhqtef2ZchlxQjv1qdBBK0NfndnmCY=";
+        "riscv-0.9.1" = "sha256-3vgERj0GY2pMRVo6sjXlch/ySeq+gdhCIlS2IWEd/+c";
         "riscv-rt-0.9.1" = "sha256-mlzGj+rFlG0IQcoX8QiSazmA0BoidSqoAADZmeyJZwE=";
         "riscv-pseudo-atomics-0.1.0" = "sha256-QuChdKbw1TTy8W+mr3gF8yDfwWcUxmAzT3j5A5gamdk";
         "riscv-semihosting-0.0.1" = "sha256-sGa++ywE9kYw9VnPKeYyzaRJsYOzF0mNE7C9c2TdUNQ=";

--- a/sys/kern/Cargo.toml
+++ b/sys/kern/Cargo.toml
@@ -19,7 +19,7 @@ cortex-m = { version = "0.7", features = ["inline-asm"] }
 cortex-m-semihosting = { version = "0.3.5", optional = true }
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
-riscv = { git = "https://github.com/rivosinc/riscv", rev = "247f8ff" }
+riscv = { git = "https://github.com/rivosinc/riscv", branch = "rivos/dev" }
 riscv-rt = "0.9.0"
 riscv-semihosting = { git = "https://github.com/rivosinc/riscv-semihosting", branch = "dev/fawaz/privilege-features", optional = true, features = ["default", "user-mode"] }
 riscv-pseudo-atomics = { git = "https://github.com/rivosinc/riscv-psuedo-atomics", branch = "rivos/main" }

--- a/sys/kern/src/arch/rv32/riscv32.rs
+++ b/sys/kern/src/arch/rv32/riscv32.rs
@@ -241,13 +241,13 @@ pub fn apply_memory_protection(task: &task::Task) {
         unsafe {
             // Configure the base address entry
             register::set_cfg_entry(i * 2, null_cfg);
-            register::write_tor_indexed(i * 2, region.base as usize);
+            register::write_tor_indexed(i * 2, region.base as u64);
 
             // Configure the end address entry
             register::set_cfg_entry(i * 2 + 1, pmpcfg);
             register::write_tor_indexed(
                 i * 2 + 1,
-                (region.base + region.size) as usize,
+                region.base as u64 + region.size as u64,
             );
         }
     }

--- a/sys/kern/src/arch/rv64/pmp.rs
+++ b/sys/kern/src/arch/rv64/pmp.rs
@@ -33,13 +33,13 @@ pub fn apply_memory_protection(task: &task::Task) {
         unsafe {
             // Configure the base address entry
             register::set_cfg_entry(i * 2, null_cfg);
-            register::write_tor_indexed(i * 2, region.base as usize);
+            register::write_tor_indexed(i * 2, region.base as u64);
 
             // Configure the end address entry
             register::set_cfg_entry(i * 2 + 1, pmpcfg);
             register::write_tor_indexed(
                 i * 2 + 1,
-                (region.base + region.size) as usize,
+                (region.base + region.size) as u64,
             );
         }
     }

--- a/test/tests-hifive-inventor/app.toml
+++ b/test/tests-hifive-inventor/app.toml
@@ -6,7 +6,7 @@ chip = "../../chips/fe310-g003"
 
 [kernel]
 name = "demo-hifive-inventor"
-requires = {flash = 16000, ram = 3232}
+requires = {flash = 16400, ram = 3232}
 features = []
 
 [tasks.runner]


### PR DESCRIPTION
This brings in some fixes to how the PMPs are handled.  I also removed some pinned versions of the riscv crate as it appears to just be an old commit on `rivos/dev`.