### PR TITLE
nix: add port option to qemu runner

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,9 +78,12 @@
 
       # build function to generate qemu test suite runners for different test apps
       hubris-test-suite-runner = (
-        {hubris}:
+        {
+          hubris,
+          port ? null,
+        }:
           pkgs.callPackage ./nix/qemu-test-suite.nix {
-            inherit hubris;
+            inherit hubris port;
             humility = humilityflake.packages.${system}.humility;
           }
       );
@@ -116,7 +119,10 @@
           toml = "test/tests-hifive-inventor/app.toml";
           # don't do check, test suite is NOT clippy clean
         };
-        tests-hifive-inventor-runner = hubris-test-suite-runner {hubris = self.packages.${system}.tests-hifive-inventor;};
+        tests-hifive-inventor-runner = hubris-test-suite-runner {
+          hubris = self.packages.${system}.tests-hifive-inventor;
+          port = "1234";
+        };
       };
 
       devShells.default = pkgs.mkShell {

--- a/nix/qemu-test-suite.nix
+++ b/nix/qemu-test-suite.nix
@@ -1,21 +1,25 @@
 {
+  lib,
   runCommand,
   hubris,
   humility,
   qemu,
-}:
-runCommand ("hubris-qemu-tests-" + hubris.app) {}
-''
-  echo "running hubris test suite for: " ${hubris.app}
+  port ? null,
+}: let
+  port_string = lib.optionalString (lib.isString port) "-p ${port}";
+in
+  runCommand ("hubris-qemu-tests-" + hubris.app) {}
+  ''
+    echo "running hubris test suite for: " ${hubris.app}
 
-  # prepare environment
-  mkdir -p $out
-  export PATH=${qemu}/bin/:$PATH
-  export HUMILITY_ARCHIVE=${hubris}/build-${hubris.app}.zip
+    # prepare environment
+    mkdir -p $out
+    export PATH=${qemu}/bin/:$PATH
+    export HUMILITY_ARCHIVE=${hubris}/build-${hubris.app}.zip
 
-  # we expect this to timeout, so ensure it always gives a good return value
-  timeout -k 1s 10s ${humility}/bin/humility qemu | tee $out/qemu.log || true
+    # we expect this to timeout, so ensure it always gives a good return value
+    timeout -k 1s 10s ${humility}/bin/humility qemu ${port_string} | tee $out/qemu.log || true
 
-  grep "done pass" $out/qemu.log
-  echo "test suite passed"
-''
+    grep "done pass" $out/qemu.log
+    echo "test suite passed"
+  ''


### PR DESCRIPTION
This allows multiple runners to be started concurrently.  If no port is specified, it will omit the parameter and allow humility to choose the default.