### PR TITLE
xtask: genreate `vmem` output.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,7 @@
         nativeBuildInputs = with pkgs; [
           rust
           binutils
+          srecord
           git
           qemu
           openocd

--- a/nix/xtask.nix
+++ b/nix/xtask.nix
@@ -3,6 +3,7 @@
   stdenv,
   rustPlatform,
   binutils,
+  srecord,
   cargo,
   rustc,
   src,
@@ -43,6 +44,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [
     binutils
+    srecord
   ];
 
   buildPhase = ''


### PR DESCRIPTION
The `vmem` output is useful for RTL simulations.  This adds the dependency on srec_cat being on the path.

Mirrors https://gitlab.ba.rivosinc.com/rv/sw/ext/hubris/-/merge_requests/67